### PR TITLE
feat: add queue pagination, search, insert play; fix playback issues

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+node_modules/
+config.json
+*.log
+.env
+*.tmp
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -1,2 +1,41 @@
-# utahime
-A discord music bot would update forever, easy to deploy
+🛠 Changes
+
+This PR includes the following updates:
+🎵 New Features
+
+    Added pagination to queue display (10 songs per page)
+
+    Supported queue search and page navigation via interaction buttons
+
+    Added insert play feature: push a selected song to the front of the queue and play it next
+
+    Added "return to playlist" button in search results to go back to the full queue view
+    ⚠️ Note: This button currently breaks after interaction expires — global registration of interactions is not yet implemented
+
+🐞 Bug Fixes
+
+    Fixed bot crashes that occurred during certain playback scenarios
+
+    Fixed issue where some YouTube links could not be played
+
+    Fixed commands not responding correctly under specific conditions
+
+🔧 Other Improvements
+
+    Refactored play.js, queue.js, and related modules for improved modularity and readability
+
+    Introduced lib/ and handlers/ directories to separate concerns
+
+    Added .gitignore to prevent committing node_modules/, config.json, .env, and other sensitive or large files
+
+✅ Testing
+
+All features were tested locally in a Discord server:
+
+    Queue pagination and navigation
+
+    Insert play logic and immediate playback
+
+    Song search functionality
+
+    Button-based interaction and partial recovery

--- a/README.md
+++ b/README.md
@@ -1,41 +1,42 @@
-🛠 Changes
+# 🛠 Changes
 
 This PR includes the following updates:
-🎵 New Features
 
-    Added pagination to queue display (10 songs per page)
+## 🎵 New Features
 
-    Supported queue search and page navigation via interaction buttons
+Added pagination to queue display (10 songs per page)
 
-    Added insert play feature: push a selected song to the front of the queue and play it next
+Supported queue search and page navigation via interaction buttons
 
-    Added "return to playlist" button in search results to go back to the full queue view
-    ⚠️ Note: This button currently breaks after interaction expires — global registration of interactions is not yet implemented
+Added insert play feature: push a selected song to the front of the queue and play it next
 
-🐞 Bug Fixes
+Added "return to playlist" button in search results to go back to the full queue view
+⚠️ Note: This button currently breaks after interaction expires — global registration of interactions is not yet implemented
 
-    Fixed bot crashes that occurred during certain playback scenarios
+## 🐞 Bug Fixes
 
-    Fixed issue where some YouTube links could not be played
+Fixed bot crashes that occurred during certain playback scenarios
 
-    Fixed commands not responding correctly under specific conditions
+Fixed issue where some YouTube links could not be played
 
-🔧 Other Improvements
+Fixed commands not responding correctly under specific conditions
 
-    Refactored play.js, queue.js, and related modules for improved modularity and readability
+## 🔧 Other Improvements
 
-    Introduced lib/ and handlers/ directories to separate concerns
+Refactored play.js, queue.js, and related modules for improved modularity and readability
 
-    Added .gitignore to prevent committing node_modules/, config.json, .env, and other sensitive or large files
+Introduced lib/ and handlers/ directories to separate concerns
 
-✅ Testing
+Added .gitignore to prevent committing node_modules/, config.json, .env, and other sensitive or large files
+
+## ✅ Testing
 
 All features were tested locally in a Discord server:
 
-    Queue pagination and navigation
+Queue pagination and navigation
 
-    Insert play logic and immediate playback
+Insert play logic and immediate playback
 
-    Song search functionality
+Song search functionality
 
-    Button-based interaction and partial recovery
+Button-based interaction and partial recovery

--- a/bot.js
+++ b/bot.js
@@ -1,13 +1,18 @@
-const {EmbedBuilder} = require('discord.js');
-const {joinVoiceChannel, createAudioPlayer, createAudioResource} = require("@discordjs/voice");
+const { EmbedBuilder } = require('discord.js');
+const { ActionRowBuilder, ButtonBuilder, ButtonStyle, ModalBuilder, StringSelectMenuBuilder, TextInputBuilder, TextInputStyle, Events, ComponentType } = require('discord.js');
+const { joinVoiceChannel, createAudioPlayer, createAudioResource } = require("@discordjs/voice");
 const Genius = require("genius-lyrics");
-const {geniusId} = require('./config.json');
+const { geniusId } = require('./config.json');
 const lyricClient = new Genius.Client(geniusId);
 const ytdl = require('@distube/ytdl-core');
+const { DisTube } = require('distube');
 const play = require('play-dl');
 require("tweetnacl");
 require("ffmpeg-static");
-
+const { AudioPlayerStatus } = require('@discordjs/voice');
+const prism = require('prism-media');
+// const { safeReply } = require('./checkReply');
+// console.log('[DEBUG] prism-media Opus loaded:', prism.opus.Encoder !== undefined);
 //Music bot class
 class Bot {
     //constructor
@@ -16,53 +21,137 @@ class Bot {
         this.player = {};
         this.queue = {};
         this.isPlaying = {};
+        this.left = {};
+        this.searchResults = {};
+    }
+    insertTop(guildId, song) {
+        if (!this.queue[guildId]) this.queue[guildId] = [];
+        //this.player[guildId].stop();
+        const queue = this.queue[guildId];
+        // If the queue is empty, just push the song
+        if (queue.length === 0) {
+            // if queue is empty, just push the song
+            queue.push(song);
+        } else {
+            // otherwise, insert the song at index 1
+            // cant use unshift because it would break the queue order
+            queue.splice(1, 0, song);
+        }
+    }
+    generateEmbed(queue, page, pageSize = 10) {
+        const totalPages = Math.ceil(queue.length / pageSize);
+        const start = page * pageSize;
+        const end = start + pageSize;
+        const pageItems = queue.slice(start, end);
+        const description = pageItems.map((item, idx) => `[${start + idx + 1}] ${item.title}`).join('\n');
+        return new EmbedBuilder()
+            .setColor('#2ECC71')
+            .setTitle('Current queue:')
+            .setDescription(description)
+            .setFooter({ text: `Page ${page + 1} of ${totalPages}` })
+            .setTimestamp();
     }
 
-    //Play music with url
-    async play(interaction, url) {
-        //If user is not in a voice channel
-        if (!interaction.member.voice.channel) {
-            await interaction.editReply({
+    createActionRow(page, totalPages) {
+        return new ActionRowBuilder().addComponents(
+            new ButtonBuilder().setCustomId('prev').setLabel('⬅ Previous').setStyle(ButtonStyle.Secondary).setDisabled(page === 0),
+            new ButtonBuilder().setCustomId('next').setLabel('Next ➡').setStyle(ButtonStyle.Secondary).setDisabled(page === totalPages - 1),
+            new ButtonBuilder().setCustomId('jump').setLabel('🔢 Jump to Page').setStyle(ButtonStyle.Primary),
+            new ButtonBuilder().setCustomId('search').setLabel('🔍 Search').setStyle(ButtonStyle.Success)
+        );
+    }
+
+    updateQueuePage(interaction, embed, components) {
+        if (interaction.deferred || interaction.replied) {
+            // already replied or deferred, use editReply
+            return interaction.editReply({
+                embeds: [embed],
+                components: components
+            });
+        } else if (interaction.isButton()) {
+            // button interaction, use update
+            return interaction.update({
+                embeds: [embed],
+                components: components
+            });
+        } else {
+            // fallback to reply
+            console.warn('[updateQueuePage] Interaction is neither deferred nor replied, using reply instead');
+            return interaction.reply({
+                embeds: [embed],
+                components: components,
+                ephemeral: true
+            });
+        }
+    }
+    // playNext function to play next track in queue
+    async playNext(id) {
+        if (this.left[id]) {
+            console.warn(`[dispatchPlaylist] Guild ${id} already left, skipping playNext`);
+            return;
+        }
+        this.left[id] = false;
+        const track = this.queue[id]?.[0];
+        if (!track) {
+            this.isPlaying[id] = false;
+            if (this.connection[id] && this.connection[id].state.status !== 'destroyed') {
+                this.connection[id].destroy();
+            } //make sure to destroy the connection
+            // this.connection[id].destroy();
+            track?.interaction.channel.send({
                 embeds: [new EmbedBuilder()
-                    .setColor('#E74C3C')
-                    .setTitle('Please join a voice channel first')
+                    .setColor('#3498DB')
+                    .setTitle('End of queue')
                     .setDescription('.help for commands')
                     .setTimestamp()]
             });
+            return;
         }
-        if (!url.includes("youtube.com")) {
-            //Url is invalid
-            await interaction.editReply({
+        try {
+            const stream = ytdl(track.url, {
+                filter: 'audioonly',
+                highWaterMark: 1 << 26, // 64MB
+                quality: 'highestaudio', // 'highestaudio' for best quality
+                /*quality: 0,*/
+                liveBuffer: 4000,
+                dlChunkSize: 64 * 1024, // avoid -1 issue
+                /*dlChunkSize: 0,*/
+                requestOptions: {
+                    timeout: 30000 // 30 seconds timeout
+                }
+            });
+            stream.on('error', err => {
+                console.error('[Stream Error]', err);
+                this.queue[id].shift();
+                this.playNext(id);
+            });
+            const resource = createAudioResource(stream, { inlineVolume: true });
+            resource.volume.setVolume(1.0);
+            //const resource = createAudioResource(stream);
+            this.player[id].play(resource);
+            track.interaction.channel.send({
                 embeds: [new EmbedBuilder()
-                    .setColor('#E74C3C')
-                    .setTitle('This is not an valid YouTube url')
-                    .setDescription('Use /search if you want to queue a track with keywords')
+                    .setColor('#3498DB')
+                    .setTitle('Now playing:')
+                    .setDescription(track.title)
+                    .setURL(track.url)
                     .setTimestamp()]
             });
-        } else if (url.includes("playlist")) {
-            //Url is a playlist
-            await this.dispatchPlaylist(interaction, url);
-        } else {
-            //Url is a track
-            return this.dispatch(interaction, url, false);
+        } catch (error) {
+            console.error(`[playNext Error] ${error.message}`);
+            this.queue[id].shift();
+            this.playNext(id); // play next track
         }
     }
-
-    //Search tracks with keywords
-    async search(keywords) {
-        //Fetch possible results from YouTube (5 items)
-        const musicTitle = await play.search(keywords, {limit: 5});
-        const choices = [];
-        for (const youTubeVideo of musicTitle) {
-            choices.push([youTubeVideo.title, youTubeVideo.url]);
-        }
-        //Return results array to command call
-        return choices;
-    }
-
     //Fetch single track url
     async dispatch(interaction, url, isPlaylist) {
+
         const id = interaction.guildId;
+        if (this.left[id]) {
+            console.warn(`[dispatchPlaylist] Guild ${id} already left, skipping dispatch`);
+            return;
+        }
+        this.left[id] = false;
         //Join voice channel
         if (this.connection[id] == null || this.connection[id].state.status === "destroyed") {
             this.connection[id] = joinVoiceChannel({
@@ -70,13 +159,27 @@ class Bot {
                 guildId: id,
                 adapterCreator: interaction.guild.voiceAdapterCreator
             });
-            this.player[id] = createAudioPlayer();
+            this.player[id] = createAudioPlayer({
+                behaviors: {
+                    maxMissedFrames: 8 // default is 5, increase to avoid disconnects
+                }
+            });
             this.connection[id].subscribe(this.player[id]);
+            // add listeners for player events
+            this.player[id].on(AudioPlayerStatus.Idle, () => {
+                this.queue[id].shift();
+                this.playNext(id);
+            });
+            this.player[id].on('error', error => {
+                console.error(`[AudioPlayer Error]: ${error.message}`);
+                this.queue[id].shift();
+                this.playNext(id);
+            });
         }
         try {
             //Fetch track info with play dl from YouTube
             let info = await ytdl.getBasicInfo(url);
-            let stream = ytdl(url, { filter: 'audioonly' });
+            // console.log('[dispatch]', info.videoDetails.title, url);
             if (!this.queue[id]) {
                 this.queue[id] = [];
             }
@@ -85,7 +188,6 @@ class Bot {
                 interaction: interaction,
                 title: info.videoDetails.title,
                 url: url,
-                stream: stream
             });
             //Check if call is from fetchPlaylist
             if (!isPlaylist) {
@@ -96,239 +198,99 @@ class Bot {
                         .setTitle('Track queued:')
                         .setDescription(info.videoDetails.title)
                         .setURL(url)
-                        .setTimestamp()], components: [], ephemeral: true
+                        .setTimestamp()], components: [], flags: 64
                 });
             }
+            if (!this.isPlaying[id]) {
+                this.isPlaying[id] = true;
+                this.playNext(id);
+            }
+
         } catch (e) {
             //Edit command call with failure message
             await interaction.editReply({
                 embeds: [new EmbedBuilder()
                     .setColor('#E74C3C')
                     .setTitle('This track is currently unavailable')
-                    .setTimestamp()], components: [], ephemeral: true
-            });
-        }
-        //Check if bot is already playing in the command call server
-        if (!this.isPlaying[id]) {
-            //Update isPlaying
-            this.isPlaying[id] = true;
-            this.player[id].play(createAudioResource(this.queue[id][0].stream, {inputType: this.queue[id][0].stream.type}));
-            //Broadcast player info / status
-            interaction.channel.send({
-                embeds: [new EmbedBuilder()
-                    .setColor('#3498DB')
-                    .setTitle('Now playing:')
-                    .setDescription(this.queue[id][0].title)
-                    .setURL(this.queue[id][0].url)
-                    .setTimestamp()
-                ]
-            });
-            //Player watchdog
-            this.player[id].on("idle", () => {
-                //Auto shifting tracks
-                this.queue[id].shift();
-                if (this.queue[id].length > 0) {
-                    //Broadcast player info / status
-                    this.queue[id][0].interaction.channel.send({
-                        embeds: [new EmbedBuilder()
-                            .setColor('#3498DB')
-                            .setTitle('Now playing:')
-                            .setDescription(this.queue[id][0].title)
-                            .setURL(this.queue[id][0].url)
-                            .setTimestamp()
-                        ]
-                    });
-                    this.player[id].play(createAudioResource(this.queue[id][0].stream, {inputType: this.queue[id][0].stream.type}));
-                } else {
-                    if (this.isPlaying[id] === true) {
-                        this.isPlaying[id] = false;
-                        //Broadcast player info / status
-                        interaction.channel.send({
-                            embeds: [new EmbedBuilder()
-                                .setColor('#3498DB')
-                                .setTitle('End of queue')
-                                .setDescription('.help for commands')
-                                .setTimestamp()]
-                        });
-                        this.connection[id].destroy();
-                    }
-                }
+                    .setTimestamp()], components: [], flags: 64
             });
         }
     }
 
     //Fetch playlist url
     async dispatchPlaylist(interaction, url) {
+        const id = interaction.guildId;
+        if (this.left[id]) {
+            return;
+        }
+        this.left[id] = false;
         try {
             //Fetch playlist info with play dl from YouTube
             const playlist = await play.playlist_info(url);
             const videos = await playlist.all_videos();
             //Queue tracks
             for (let i = 0; i < videos.length; i++) {
+                if (this.left[id]) {
+                    console.warn(`[dispatchPlaylist] Guild ${id} leaft during playlist dispatch, stopping further processing`);
+                    break;
+                }
                 await this.dispatch(interaction, videos[i].url, true);
             }
             //Edit command call if playlist fetch successes
-            await interaction.editReply({
-                embeds: [new EmbedBuilder()
-                    .setColor('#3498DB')
-                    .setTitle('Playlist queued:')
-                    .setDescription(playlist.title)
-                    .setURL(url)
-                    .setTimestamp()], components: [], ephemeral: true
-            });
+            if (!this.left[id]) {
+                await interaction.reply({
+                    embeds: [new EmbedBuilder()
+                        .setColor('#3498DB')
+                        .setTitle('Playlist queued:')
+                        .setDescription(playlist.title)
+                        .setURL(url)
+                        .setTimestamp()], components: [], flags: 64
+                });
+            }
         } catch (e) {
             //Edit command call if playlist fetching failed
             await interaction.editReply({
                 embeds: [new EmbedBuilder()
                     .setColor('#E74C3C')
                     .setTitle('This playlist is currently unavailable')
-                    .setTimestamp()], components: [], ephemeral: true
-            });
-        }
-    }
-
-    //Force bot leave the voice channel currently in
-    leave(interaction) {
-        const id = interaction.guildId
-        //Check bot status
-        if (this.connection[id] && this.connection[id].state.status === "ready") {
-            //Clear status
-            if (this.queue.hasOwnProperty(id)) {
-                delete this.queue[id];
-                this.isPlaying[id] = false;
-            }
-            this.connection[id].destroy();
-            //React command call
-            interaction.reply({
-                embeds: [new EmbedBuilder()
-                    .setColor('#E74C3C')
-                    .setTitle('ヾ(￣▽￣)Bye~Bye~')
-                    .setTimestamp()
-                ]
-            });
-        } else {
-            //If bot is not in any channel
-            interaction.reply({
-                embeds: [new EmbedBuilder()
-                    .setColor('#E74C3C')
-                    .setTitle('I\'m not in any channel')
-                    .setDescription('.help for commands')
-                    .setTimestamp()
-                ]
-            });
-        }
-    }
-
-    //Skip
-    skip(interaction) {
-        const id = interaction.guildId
-        //Check player existence
-        if (this.player[id]) {
-            //Reply command call
-            interaction.reply({
-                embeds: [new EmbedBuilder()
-                    .setColor('#2ECC71')
-                    .setTitle('Skip current track')
-                    .setTimestamp()
-                ]
-            });
-            this.player[id].stop(true);
-        }
-    }
-
-    //Pause
-    pause(interaction) {
-        const id = interaction.guildId
-        //Check player existence
-        if (this.player[id]) {
-            //Reply command call
-            interaction.reply({
-                embeds: [new EmbedBuilder()
-                    .setColor('#E74C3C')
-                    .setTitle('Pause playing')
-                    .setTimestamp()
-                ]
-            });
-            this.player[id].pause();
-        }
-    }
-
-    //Resume
-    resume(interaction) {
-        const id = interaction.guildId
-        //Check player existence
-        if (this.player[id]) {
-            //Reply command call
-            interaction.reply({
-                embeds: [new EmbedBuilder()
-                    .setColor('#3498DB')
-                    .setTitle('Resume playing')
-                    .setTimestamp()
-                ]
-            });
-            this.player[id].unpause();
-        }
-    }
-
-    //Queue status process
-    async viewQueue(interaction) {
-        const id = interaction.guildId
-        //Check queue existence
-        if (this.queue[id] && this.queue[id].length > 0) {
-            //Construct queue string
-            const queueString = this.queue[id].map((item, index) => `\n[${index + 1}] ${item.title}`).join();
-            //Return embed queue string
-            await interaction.reply({
-                embeds: [new EmbedBuilder()
-                    .setColor('#2ECC71')
-                    .setTitle('Current queue:')
-                    .setDescription(queueString)
-                    .setTimestamp()]
-            });
-        } else {
-            //If queue is empty / does not exist
-            await interaction.reply({
-                embeds: [new EmbedBuilder()
-                    .setColor('#E74C3C')
-                    .setTitle('There\'s no track in queue')
-                    .setTimestamp()]
+                    .setTimestamp()], components: [], flags: 64
             });
         }
     }
 
     //Get lyrics of current playing track / specified track
-    async lyric(interaction, title) {
-        const id = interaction.guildId
-        try {
-            //If 'title' argument is not provided
-            if (!title) {
-                //Assign 'title' with current playing track
-                title = this.queue[id][0].title;
-            }
-            //Fetch lyric with track title
-            const searches = await lyricClient.songs.search(title);
-            const song = searches[0];
-            const lyric = await song.lyrics();
-            //Return embed message with fetched lyrics
-            await interaction.reply({
-                embeds: [new EmbedBuilder()
-                    .setColor('#3498DB')
-                    .setTitle(song.title)
-                    .setURL(song.url)
-                    .setDescription(lyric)
-                    .setTimestamp()]
-            });
-        } catch (e) {
-            //Lyric with given title can not be found
-            await interaction.reply({
-                embeds: [new EmbedBuilder()
-                    .setColor('#E74C3C')
-                    .setTitle('Lyric not found with title:')
-                    .setDescription(title)
-                    .setTimestamp()]
-            });
-        }
-    }
+    // async lyric(interaction, title) {
+    //     const id = interaction.guildId
+    //     try {
+    //         //If 'title' argument is not provided
+    //         if (!title) {
+    //             //Assign 'title' with current playing track
+    //             title = this.queue[id][0].title;
+    //         }
+    //         //Fetch lyric with track title
+    //         const searches = await lyricClient.songs.search(title);
+    //         const song = searches[0];
+    //         const lyric = await song.lyrics();
+    //         //Return embed message with fetched lyrics
+    //         await interaction.reply({
+    //             embeds: [new EmbedBuilder()
+    //                 .setColor('#3498DB')
+    //                 .setTitle(song.title)
+    //                 .setURL(song.url)
+    //                 .setDescription(lyric)
+    //                 .setTimestamp()]
+    //         });
+    //     } catch (e) {
+    //         //Lyric with given title can not be found
+    //         await interaction.reply({
+    //             embeds: [new EmbedBuilder()
+    //                 .setColor('#E74C3C')
+    //                 .setTitle('Lyric not found with title:')
+    //                 .setDescription(title)
+    //                 .setTimestamp()]
+    //         });
+    //     }
+    // }
 }
 
 //Export class

--- a/bot.js
+++ b/bot.js
@@ -11,6 +11,7 @@ require("tweetnacl");
 require("ffmpeg-static");
 const { AudioPlayerStatus } = require('@discordjs/voice');
 const prism = require('prism-media');
+const { fixPlaylistUrl } = require('./handlers/fixPlaylistUrl');
 // const { safeReply } = require('./checkReply');
 // console.log('[DEBUG] prism-media Opus loaded:', prism.opus.Encoder !== undefined);
 //Music bot class
@@ -226,8 +227,40 @@ class Bot {
         this.left[id] = false;
         try {
             //Fetch playlist info with play dl from YouTube
-            const playlist = await play.playlist_info(url);
-            const videos = await playlist.all_videos();
+            // 
+            const safeUrl = fixPlaylistUrl(url);
+            if (!safeUrl) {
+                await interaction.editReply({
+                    embeds: [new EmbedBuilder()
+                        .setColor('#E74C3C')
+                        .setTitle('This is not a valid YouTube playlist url')
+                        .setDescription('Use /search to queue with keywords')
+                        .setTimestamp()], components: [], flags: 64
+                });
+                return;
+            }
+            // console.log(safeUrl)
+            const playlist = await play.playlist_info(safeUrl);
+            let videos = [];
+            try {
+                videos = await playlist.all_videos();
+            } catch (e) {
+                console.warn('all_videos failed, using partial list');
+                videos = playlist.videos;
+            }
+            console.log(`[Playlist] Found ${videos.length} videos`);
+
+            if (videos.length === 0) {
+                return await interaction.editReply({
+                    embeds: [new EmbedBuilder()
+                        .setColor('#E67E22')
+                        .setTitle('No playable videos found in the playlist.')
+                        .setTimestamp()],
+                    components: [], flags: 64
+                });
+            }
+            // const playlist = await play.playlist_info(url);
+            // const videos = await playlist.all_videos();
             //Queue tracks
             for (let i = 0; i < videos.length; i++) {
                 if (this.left[id]) {
@@ -255,6 +288,7 @@ class Bot {
                     .setTitle('This playlist is currently unavailable')
                     .setTimestamp()], components: [], flags: 64
             });
+            console.error(`[dispatchPlaylist Error] ${e.message}`);
         }
     }
 

--- a/checkReply.js
+++ b/checkReply.js
@@ -1,0 +1,11 @@
+async function safeReply(interaction, messageOptions) {
+    if (interaction.replied || interaction.deferred) {
+        return interaction.followUp(messageOptions);
+    } else {
+        return interaction.reply(messageOptions);
+    }
+}
+
+module.exports = {
+    safeReply
+};

--- a/commands/music/leave.js
+++ b/commands/music/leave.js
@@ -1,11 +1,12 @@
-const {SlashCommandBuilder} = require('discord.js');
+const { SlashCommandBuilder } = require('discord.js');
+const leave = require('../../lib/leave');
 
 module.exports = {
     data: new SlashCommandBuilder()
         .setName('leave')
         .setDescription('Make bot leave voice channel'),
+
     async execute(interaction, bot) {
-        //Process in bot instance
-        bot.leave(interaction);
+        await leave(interaction, bot);
     },
 };

--- a/commands/music/pause.js
+++ b/commands/music/pause.js
@@ -1,4 +1,5 @@
 const {SlashCommandBuilder} = require('discord.js');
+const pause = require('../../lib/pause');
 
 module.exports = {
     data: new SlashCommandBuilder()
@@ -6,6 +7,6 @@ module.exports = {
         .setDescription('Pause track from playing'),
     async execute(interaction, bot) {
         //Process in bot instance
-        await bot.pause(interaction);
+        await pause(interaction, bot);
     },
 };

--- a/commands/music/play.js
+++ b/commands/music/play.js
@@ -1,4 +1,5 @@
-const {SlashCommandBuilder, EmbedBuilder} = require('discord.js');
+const { SlashCommandBuilder, EmbedBuilder } = require('discord.js');
+const play = require('../../lib/play');
 
 module.exports = {
     data: new SlashCommandBuilder()
@@ -9,16 +10,18 @@ module.exports = {
                 .setDescription('Url of track')
                 .setRequired(true)),
     async execute(interaction, bot) {
+        await interaction.deferReply({ flags: 64 });
         //Temporary reply, since this process takes time sometimes
-        await interaction.reply({
+        await interaction.editReply({
             embeds: [new EmbedBuilder()
                 .setColor('#3498DB')
                 .setTitle('Loading ...')
-                .setTimestamp()], components: [], ephemeral: true
+                .setTimestamp()], components: [], flags: 64
         });
         //Fetch required argument
         let url = interaction.options.getString('url');
+        console.log('[play command] url:', url);
         //Process in bot instance
-        await bot.play(interaction, url);
+        await play(interaction, url, bot);
     },
 };

--- a/commands/music/queue.js
+++ b/commands/music/queue.js
@@ -1,4 +1,5 @@
-const {SlashCommandBuilder} = require('discord.js');
+const { SlashCommandBuilder } = require('discord.js');
+const queue = require('../../lib/queue');
 
 module.exports = {
     data: new SlashCommandBuilder()
@@ -6,6 +7,6 @@ module.exports = {
         .setDescription('View current queue'),
     async execute(interaction, bot) {
         //Process in bot instance
-        await bot.viewQueue(interaction);
+        await queue(interaction, bot);
     },
 };

--- a/commands/music/resume.js
+++ b/commands/music/resume.js
@@ -1,4 +1,5 @@
 const {SlashCommandBuilder} = require('discord.js');
+const resume = require('../../lib/resume');
 
 module.exports = {
     data: new SlashCommandBuilder()
@@ -6,6 +7,6 @@ module.exports = {
         .setDescription('Resume track from pausing'),
     async execute(interaction, bot) {
         //Process in bot instance
-        bot.resume(interaction);
+        resume(interaction, bot);
     },
 };

--- a/commands/music/search.js
+++ b/commands/music/search.js
@@ -1,4 +1,6 @@
-const {SlashCommandBuilder, ActionRowBuilder, ButtonBuilder, ButtonStyle, EmbedBuilder} = require('discord.js');
+const { SlashCommandBuilder, EmbedBuilder } = require('discord.js');
+const { searchTracks, buildSearchEmbed, buildButtonRow } = require('../../lib/search');
+// const play = require('../../lib/play');
 
 module.exports = {
     data: new SlashCommandBuilder()
@@ -7,69 +9,36 @@ module.exports = {
         .addStringOption(option =>
             option.setName('keywords')
                 .setDescription('Keywords of track')
-                .setRequired(true)),
+                .setRequired(true)
+        ),
+
     async execute(interaction, bot) {
-        //Temporary reply, since this process takes time sometimes
-        await interaction.reply({
-            embeds: [new EmbedBuilder()
-                .setColor('#3498DB')
-                .setTitle('Loading ...')
-                .setTimestamp()], components: [], ephemeral: true
+        await interaction.deferReply({ flags: 64 });
+
+        const keywords = interaction.options.getString('keywords');
+        const choices = await searchTracks(keywords);
+        const embed = buildSearchEmbed(choices);
+        const row = buildButtonRow(choices.length);
+
+        const reply = await interaction.editReply({
+            embeds: [embed],
+            components: [row],
+            flags: 64
         });
-        //Fetch required argument
-        let keywords = interaction.options.getString('keywords')
-        //Process in bot instance
-        let choices = await bot.search(keywords)
-        //Build embed message
-        const choicesEmbed = new EmbedBuilder()
-            .setColor('#2ECC71')
-            .setTitle('Please select a track:')
-            .setDescription('[1] ' + choices[0][0] + '\n\n' +
-                '[2] ' + choices[1][0] + '\n\n' +
-                '[3] ' + choices[2][0] + '\n\n' +
-                '[4] ' + choices[3][0] + '\n\n' +
-                '[5] ' + choices[4][0])
-            .setTimestamp();
-        const one = new ButtonBuilder()
-            .setCustomId('0')
-            .setLabel('1')
-            .setStyle(ButtonStyle.Secondary);
-        const two = new ButtonBuilder()
-            .setCustomId('1')
-            .setLabel('2')
-            .setStyle(ButtonStyle.Secondary);
-        const three = new ButtonBuilder()
-            .setCustomId('2')
-            .setLabel('3')
-            .setStyle(ButtonStyle.Secondary);
-        const four = new ButtonBuilder()
-            .setCustomId('3')
-            .setLabel('4')
-            .setStyle(ButtonStyle.Secondary);
-        const five = new ButtonBuilder()
-            .setCustomId('4')
-            .setLabel('5')
-            .setStyle(ButtonStyle.Secondary);
-        const row = new ActionRowBuilder()
-            .addComponents(one, two, three, four, five);
-        //Edit command call with searched data with user prompted keywords
-        const reply = await interaction.editReply({embeds: [choicesEmbed], components: [row], ephemeral: true})
-        //Handle user replies
-        const collectorFilter = i => i.user.id === interaction.user.id;
+
         try {
-            const confirmation = await reply.awaitMessageComponent({filter: collectorFilter, time: 30_000});
-            //Fetch user selected track url
-            const url = choices[parseInt(confirmation.customId)][1]
-            //Process in bot instance
-            await bot.play(interaction, url)
-        } catch (e) {
-            //Build time out embed message
+            const filter = i => i.user.id === interaction.user.id;
+            const confirmation = await reply.awaitMessageComponent({ filter, time: 30_000 });
+            const url = choices[parseInt(confirmation.customId)][1];
+
+            // await play(interaction, url, bot);
+            await bot.dispatch(interaction, url, false);
+        } catch {
             const cancelEmbed = new EmbedBuilder()
                 .setColor('#E74C3C')
-                .setTitle('No chosen received, queue action canceled')
+                .setTitle('No response received, action canceled')
                 .setTimestamp();
-            //Edit timed out command call
-            await interaction.editReply({embeds: [cancelEmbed], components: [], ephemeral: true});
+            await interaction.editReply({ embeds: [cancelEmbed], components: [], flags: 64 });
         }
     },
 };

--- a/commands/music/skip.js
+++ b/commands/music/skip.js
@@ -1,4 +1,5 @@
-const {SlashCommandBuilder} = require('discord.js');
+const { SlashCommandBuilder } = require('discord.js');
+const skip = require('../../lib/skip');
 
 module.exports = {
     data: new SlashCommandBuilder()
@@ -6,6 +7,6 @@ module.exports = {
         .setDescription('Skip current track'),
     async execute(interaction, bot) {
         //Process in bot instance
-        bot.skip(interaction);
+        await skip(interaction, bot);
     },
 };

--- a/disable-ipv6.txt
+++ b/disable-ipv6.txt
@@ -1,0 +1,24 @@
+Title: Disable IPv6 on Ubuntu to Fix YouTube Streaming Issues
+
+Problem:
+When running the Discord music bot on Ubuntu, songs may stop playing after a few seconds due to streaming errors such as:
+- ETIMEDOUT
+- ENETUNREACH
+
+Cause:
+The system tries to connect to YouTube's CDN using IPv6 first, but fails because IPv6 is not properly configured or not reachable. This causes the stream to timeout and disconnect.
+
+Solution:
+Disable IPv6 on the system so it always uses IPv4, which is more reliable in most environments.
+
+Temporary (until reboot):
+sudo sysctl -w net.ipv6.conf.all.disable_ipv6=1
+sudo sysctl -w net.ipv6.conf.default.disable_ipv6=1
+
+Permanent (survives reboot):
+echo "net.ipv6.conf.all.disable_ipv6 = 1" | sudo tee -a /etc/sysctl.conf
+echo "net.ipv6.conf.default.disable_ipv6 = 1" | sudo tee -a /etc/sysctl.conf
+sudo sysctl -p
+
+Make sure to apply this if your bot encounters connection or timeout issues with YouTube audio streaming.
+

--- a/handlers/fixPlaylistUrl.js
+++ b/handlers/fixPlaylistUrl.js
@@ -1,0 +1,35 @@
+// fixPlaylistUrl.js
+/**
+ * YouTube Playlist URL Sanitizer
+ *
+ * Problem:
+ * When using the play-dl library to parse playlist URLs in the form of
+ * "https://www.youtube.com/playlist?list=...", it may throw the following error:
+ *
+ *     Error: While parsing playlist url
+ *     Unavailable videos are hidden
+ *
+ * This typically occurs when the playlist contains private, deleted, or hidden videos.
+ *
+ * However, if the URL is in the form:
+ * "https://www.youtube.com/watch?v=VIDEO_ID&list=...", where VIDEO_ID is a valid public video,
+ * play-dl is able to parse the entire playlist successfully, skipping unavailable videos.
+ *
+ * Solution:
+ * This helper function converts playlist URLs into the "watch?v=...&list=..." format
+ * by injecting a known public video ID (e.g., dQw4w9WgXcQ) to work around the issue.
+ *
+ * Recommendation:
+ * Always sanitize playlist URLs using this function before passing them to play-dl
+ * to ensure better compatibility and avoid parsing failures.
+ */
+function fixPlaylistUrl(url) {
+    const u = new URL(url);
+    if (u.hostname.includes("youtube.com") && u.pathname === "/playlist" && u.searchParams.has("list")) {
+        // Inject a known public video ID to ensure play-dl can parse the playlist
+        return `https://www.youtube.com/watch?v=dQw4w9WgXcQ&list=${u.searchParams.get("list")}`;
+    }
+    return url;
+}
+
+module.exports = { fixPlaylistUrl };

--- a/handlers/interactionHandler.js
+++ b/handlers/interactionHandler.js
@@ -1,0 +1,131 @@
+// interactionHandlers.js
+const { ActionRowBuilder, ButtonBuilder, ButtonStyle, StringSelectMenuBuilder, Events, EmbedBuilder } = require('discord.js');
+// const { renderQueueEmbed } = require('./queueView');
+
+function registerInteractionHandlers(client, bot) {
+    client.on(Events.InteractionCreate, async interaction => {
+        if (interaction.isModalSubmit()) {
+            const id = interaction.guildId;
+            const queue = bot.queue[id] || [];
+            const PAGE_SIZE = 10;
+            const totalPages = Math.ceil(queue.length / PAGE_SIZE);
+
+            if (interaction.customId === 'jumpModal') {
+                const pageInput = interaction.fields.getTextInputValue('pageNumber');
+                const pageNum = parseInt(pageInput, 10) - 1;
+
+                if (isNaN(pageNum) || pageNum < 0) {
+                    return await interaction.reply({ content: '❌ Invalid page number.', flags: 64 });
+                }
+
+                const id = interaction.guildId;
+                const queue = bot.queue[id] || [];
+                const PAGE_SIZE = 10;
+                const totalPages = Math.ceil(queue.length / PAGE_SIZE);
+                if (pageNum >= totalPages) {
+                    return await interaction.reply({ content: `❌ Page number exceeds total pages (${totalPages}).`, flags: 64 });
+                }
+
+                const start = pageNum * PAGE_SIZE;
+                const end = start + PAGE_SIZE;
+                const pageItems = queue.slice(start, end);
+                const description = pageItems.map((item, idx) => `[${start + idx + 1}] ${item.title}`).join('\n');
+                const embed = new EmbedBuilder()
+                    .setColor('#2ECC71')
+                    .setTitle('Current queue:')
+                    .setDescription(description)
+                    .setFooter({ text: `Page ${pageNum + 1} of ${totalPages}` })
+                    .setTimestamp();
+
+                const createActionRow = (page) => {
+                    return new ActionRowBuilder().addComponents(
+                        new ButtonBuilder().setCustomId('prev').setLabel('⬅ Previous').setStyle(ButtonStyle.Secondary).setDisabled(page === 0),
+                        new ButtonBuilder().setCustomId('next').setLabel('Next ➡').setStyle(ButtonStyle.Secondary).setDisabled(page === totalPages - 1),
+                        new ButtonBuilder().setCustomId('jump').setLabel('📄 Jump to Page').setStyle(ButtonStyle.Primary),
+                        new ButtonBuilder().setCustomId('search').setLabel('🔍 Search').setStyle(ButtonStyle.Primary),
+                    );
+                };
+
+                await interaction.reply({
+                    embeds: [embed],
+                    components: [createActionRow(pageNum)],
+                    flags: 64
+                });
+            }
+
+            if (interaction.customId === 'searchModal') {
+                await interaction.deferReply({ flags: 64 });
+                const keyword = interaction.fields.getTextInputValue('keyword').toLowerCase();
+                const filtered = queue.filter(item => item.title.toLowerCase().includes(keyword));
+
+                if (!filtered.length) {
+                    return await interaction.editReply({ content: 'No matching songs found.', flags: 64 });
+                }
+
+                bot.searchResults ??= {};
+                bot.searchResults[id] = filtered;
+
+                if (filtered.length === 1) {
+                    bot.insertTop(id, filtered[0]);
+                    return await interaction.editReply({ content: `✅ Inserted "${filtered[0].title}" to top of queue.`, flags: 64 });
+                }
+
+                const options = filtered.slice(0, 25).map((item, index) => ({
+                    label: item.title.slice(0, 100),
+                    value: String(index),
+                }));
+                const selectMenu = new StringSelectMenuBuilder()
+                    .setCustomId('selectSong')
+                    .setPlaceholder('Select a song to insert')
+                    .addOptions(options);
+
+                const actionRow = new ActionRowBuilder().addComponents(selectMenu);
+                const backButtonRow = new ActionRowBuilder().addComponents(
+                    new ButtonBuilder()
+                        .setCustomId('backToQueue')
+                        .setLabel('⬅ Return to Queue')
+                        .setStyle(ButtonStyle.Secondary)
+                );
+                return await interaction.editReply({
+                    content: `Found ${filtered.length} songs. Choose one to insert or return.`,
+                    components: [actionRow, backButtonRow],
+                    // components:[actionRow],
+                    flags: 64,
+                });
+            }
+        }
+
+        if (interaction.isStringSelectMenu()) {
+            if (interaction.customId === 'selectSong') {
+                console.log('Test');
+                const id = interaction.guildId;
+                const index = parseInt(interaction.values[0]);
+                const selected = bot.searchResults?.[id]?.[index];
+                if (!selected) {
+                    return await interaction.reply({ content: '❌ Selection error.', flags: 64 });
+                }
+                bot.insertTop(id, selected);
+                return await interaction.update({ content: `✅ Inserted "${selected.title}" to top of queue.`, components: [] });
+            }
+        }
+
+        if (interaction.isButton()) {
+            if (interaction.customId === 'backToQueue') {
+                // back to queue button
+                // This file handles interaction events for the bot, specifically for queue management and searching tracks.
+                // const { embed, components } = renderQueueEmbed(bot, interaction.guildId, 0);
+                const id = interaction.guildId;
+                const queue = bot.queue[id] || [];
+                const totalPages = Math.ceil(queue.length / 10);
+                const embed = bot.generateEmbed(queue, 0);
+                const row = bot.createActionRow(0, totalPages);
+                await bot.updateQueuePage(interaction, embed, [row]);
+                // return bot.updateQueuePage(interaction,embed,[row]);
+                // await interaction.update({ embeds: [embed], components });
+            }
+        }
+    });
+}
+
+module.exports = { registerInteractionHandlers };
+

--- a/index.js
+++ b/index.js
@@ -3,7 +3,7 @@ const fs = require('node:fs');
 const path = require('node:path');
 const {token} = require('./config.json');
 const {Bot} = require('./bot.js');
-
+const {registerInteractionHandlers} = require('./handlers/interactionHandler');
 //Discord client instance
 const client = new Client({
     intents: [
@@ -39,7 +39,7 @@ for (const folder of commandFolders) {
         }
     }
 }
-
+registerInteractionHandlers(client, bot);
 //Discord client login
 client.login(token).then(() => {
     console.log(`Logged in as ${client.user.tag}!`);
@@ -54,9 +54,9 @@ client.on(Events.InteractionCreate, async interaction => {
     } catch (error) {
         console.error(error);
         if (interaction.replied || interaction.deferred) {
-            await interaction.followUp({content: 'There was an error while executing this command!', ephemeral: true});
+            await interaction.followUp({content: 'There was an error while executing this command!', flags: 64});
         } else {
-            await interaction.reply({content: 'There was an error while executing this command!', ephemeral: true});
+            await interaction.reply({content: 'There was an error while executing this command!', flags: 64});
         }
     }
 });

--- a/lib/leave.js
+++ b/lib/leave.js
@@ -1,0 +1,64 @@
+const { EmbedBuilder } = require('discord.js');
+const { AudioPlayerStatus } = require('@discordjs/voice');
+
+// This function safely replies to an interaction, handling both initial replies and follow-ups.
+// It ensures that if the interaction has already been replied to or deferred, it uses followUp.
+// If not, it uses reply. It also catches any errors that may occur during the reply process.
+async function safeReply(interaction, data) {
+  try {
+    if (interaction.replied || interaction.deferred) {
+      await interaction.followUp({ ...data, ephemeral: true });
+    } else {
+      await interaction.reply({ ...data, ephemeral: true });
+    }
+  } catch (err) {
+    console.error('[safeReply Error]', err);
+  }
+}
+// This function handles the leave command for a music bot.
+async function leave(interaction, bot) {
+  const id = interaction.guildId;
+  bot.left[id] = true;
+
+  const connection = bot.connection[id];
+  const player = bot.player?.[id];
+
+  if (connection && connection.state.status === "ready") {
+    if (Array.isArray(bot.queue[id])) {
+      bot.queue[id].length = 0;
+    }
+
+    if (bot.queue.hasOwnProperty(id)) {
+      delete bot.queue[id];
+      bot.isPlaying[id] = false;
+    }
+
+    if (player && player.removeAllListeners) {
+      player.removeAllListeners(AudioPlayerStatus.Idle);
+      player.removeAllListeners(AudioPlayerStatus.Playing);
+      player.stop(true);
+    }
+
+    // console.log('Queue after leave:', bot.queue[id]);
+
+    connection.destroy();
+    delete bot.connection[id];
+
+    await safeReply(interaction, {
+      embeds: [new EmbedBuilder()
+        .setColor('#E74C3C')
+        .setTitle('ヾ(￣▽￣)Bye~Bye~')
+        .setTimestamp()]
+    });
+  } else {
+    await safeReply(interaction, {
+      embeds: [new EmbedBuilder()
+        .setColor('#E74C3C')
+        .setTitle('I\'m not in any channel')
+        .setDescription('.help for commands')
+        .setTimestamp()]
+    });
+  }
+}
+
+module.exports = leave;

--- a/lib/pause.js
+++ b/lib/pause.js
@@ -1,0 +1,19 @@
+const { EmbedBuilder } = require('discord.js');
+
+async function pause(interaction, bot) {
+    const id = interaction.guildId
+    //Check player existence
+    if (bot.player[id]) {
+        //Reply command call
+        interaction.reply({
+            embeds: [new EmbedBuilder()
+                .setColor('#E74C3C')
+                .setTitle('Pause playing')
+                .setTimestamp()
+            ]
+        });
+        bot.player[id].pause();
+    }
+}
+
+module.exports = pause;

--- a/lib/play.js
+++ b/lib/play.js
@@ -1,0 +1,43 @@
+const { EmbedBuilder } = require('discord.js');
+
+async function play(interaction, url, bot) {
+    const id = interaction.guildId;
+    // console.log(bot.left[id]);
+
+    if (bot.left[id]) {
+        bot.queue[id] = [];
+        bot.isPlaying[id] = false;
+        bot.left[id] = false;
+    }
+
+    if (!bot.queue[id]) bot.queue[id] = [];
+    if (!bot.connection[id]) bot.queue[id].length = 0;
+
+    if (!interaction.member.voice.channel) {
+        await interaction.editReply({
+            embeds: [new EmbedBuilder()
+                .setColor('#E74C3C')
+                .setTitle('Please join a voice channel first')
+                .setDescription('.help for commands')
+                .setTimestamp()],
+        });
+        return;
+    }
+
+    if (!url.includes("youtube.com")) {
+        await interaction.editReply({
+            embeds: [new EmbedBuilder()
+                .setColor('#E74C3C')
+                .setTitle('This is not a valid YouTube url')
+                .setDescription('Use /search to queue with keywords')
+                .setTimestamp()],
+        });
+    } else if (url.includes("playlist") || url.includes("list")) {
+        await bot.dispatchPlaylist(interaction, url);
+    } else {
+        return bot.dispatch(interaction, url, false);
+    }
+}
+
+module.exports = play;
+

--- a/lib/queue.js
+++ b/lib/queue.js
@@ -1,0 +1,95 @@
+const { EmbedBuilder } = require('discord.js');
+const { ActionRowBuilder, ButtonBuilder, ButtonStyle, ModalBuilder, TextInputBuilder, TextInputStyle, ComponentType } = require('discord.js');
+async function queue(interaction, bot) {
+    const id = interaction.guildId;
+    const queue = bot.queue[id] || [];
+    if (!queue.length) {
+        return await interaction.reply({
+            embeds: [new EmbedBuilder()
+                .setColor('#E74C3C')
+                .setTitle('There\'s no track in queue')
+                .setTimestamp()],
+            flags: 64
+        });
+    }
+
+    const PAGE_SIZE = 10;
+    let currentPage = 0;
+    const totalPages = Math.ceil(queue.length / PAGE_SIZE);
+
+    const generateEmbed = (page) => {
+        const start = page * PAGE_SIZE;
+        const end = start + PAGE_SIZE;
+        const pageItems = queue.slice(start, end);
+        const description = pageItems.map((item, idx) => `[${start + idx + 1}] ${item.title}`).join('\n');
+        return new EmbedBuilder()
+            .setColor('#2ECC71')
+            .setTitle('Current queue:')
+            .setDescription(description)
+            .setFooter({ text: `Page ${page + 1} of ${totalPages}` })
+            .setTimestamp();
+    };
+
+    const createActionRow = (page) => {
+        return new ActionRowBuilder().addComponents(
+            new ButtonBuilder().setCustomId('prev').setLabel('⬅ Previous').setStyle(ButtonStyle.Secondary).setDisabled(page === 0),
+            new ButtonBuilder().setCustomId('next').setLabel('Next ➡').setStyle(ButtonStyle.Secondary).setDisabled(page === totalPages - 1),
+            new ButtonBuilder().setCustomId('jump').setLabel('📄 Jump to Page').setStyle(ButtonStyle.Primary),
+            new ButtonBuilder().setCustomId('search').setLabel('🔍 Search').setStyle(ButtonStyle.Primary),
+        );
+    };
+
+    await interaction.reply({
+        embeds: [generateEmbed(currentPage)],
+        components: [createActionRow(currentPage)],
+        flags: 64
+    });
+
+    const message = await interaction.fetchReply();
+    const collector = message.createMessageComponentCollector({ componentType: ComponentType.Button, time: 60000 });
+
+    collector.on('collect', async (i) => {
+        if (i.user.id !== interaction.user.id) {
+            return await i.reply({ content: '⚠️ not your interaction.', flags: 64 });
+        }
+
+        if (i.customId === 'prev') {
+            currentPage--;
+            await i.update({ embeds: [generateEmbed(currentPage)], components: [createActionRow(currentPage)] });
+        } else if (i.customId === 'next') {
+            currentPage++;
+            await i.update({ embeds: [generateEmbed(currentPage)], components: [createActionRow(currentPage)] });
+        } else if (i.customId === 'jump') {
+            const modal = new ModalBuilder()
+                .setCustomId('jumpModal')
+                .setTitle('Jump to Page')
+                .addComponents(
+                    new ActionRowBuilder().addComponents(
+                        new TextInputBuilder()
+                            .setCustomId('pageNumber')
+                            .setLabel('Enter page number:')
+                            .setStyle(TextInputStyle.Short)
+                            .setPlaceholder(`1 - ${totalPages}`)
+                            .setRequired(true)
+                    )
+                );
+            await i.showModal(modal);
+        } else if (i.customId === 'search') {
+            const modal = new ModalBuilder()
+                .setCustomId('searchModal')
+                .setTitle('Search Queue')
+                .addComponents(
+                    new ActionRowBuilder().addComponents(
+                        new TextInputBuilder()
+                            .setCustomId('keyword')
+                            .setLabel('Enter search keyword:')
+                            .setStyle(TextInputStyle.Short)
+                            .setRequired(true)
+                    )
+                );
+            await i.showModal(modal);
+        }
+    });
+}
+
+module.exports = queue;

--- a/lib/resume.js
+++ b/lib/resume.js
@@ -1,0 +1,19 @@
+const { EmbedBuilder } = require('discord.js');
+
+async function resume(interaction, bot) {
+    const id = interaction.guildId
+    //Check player existence
+    if (bot.player[id]) {
+        //Reply command call
+        interaction.reply({
+            embeds: [new EmbedBuilder()
+                .setColor('#3498DB')
+                .setTitle('Resume playing')
+                .setTimestamp()
+            ]
+        });
+        bot.player[id].unpause();
+    }
+}
+
+module.exports = resume;

--- a/lib/search.js
+++ b/lib/search.js
@@ -1,0 +1,35 @@
+const play = require('play-dl');
+const { EmbedBuilder, ActionRowBuilder, ButtonBuilder, ButtonStyle } = require('discord.js');
+
+async function searchTracks(keywords, limit = 5) {
+    const results = await play.search(keywords, { limit });
+    return results.map(video => [video.title, video.url]);
+}
+
+function buildSearchEmbed(choices) {
+    const description = choices.map((item, i) => `[${i + 1}] ${item[0]}`).join('\n\n');
+    return new EmbedBuilder()
+        .setColor('#2ECC71')
+        .setTitle('Please select a track:')
+        .setDescription(description)
+        .setTimestamp();
+}
+
+function buildButtonRow(count = 5) {
+    const row = new ActionRowBuilder();
+    for (let i = 0; i < count; i++) {
+        row.addComponents(
+            new ButtonBuilder()
+                .setCustomId(`${i}`)
+                .setLabel(`${i + 1}`)
+                .setStyle(ButtonStyle.Secondary)
+        );
+    }
+    return row;
+}
+
+module.exports = {
+    searchTracks,
+    buildSearchEmbed,
+    buildButtonRow,
+};

--- a/lib/skip.js
+++ b/lib/skip.js
@@ -1,0 +1,19 @@
+const { EmbedBuilder } = require('discord.js');
+
+async function skip(interaction, bot) {
+    const id = interaction.guildId
+    //Check player existence
+    if (bot.player[id]) {
+        //Reply command call
+        interaction.reply({
+            embeds: [new EmbedBuilder()
+                .setColor('#2ECC71')
+                .setTitle('Skip current track')
+                .setTimestamp()
+            ]
+        });
+        bot.player[id].stop(true);
+    }
+}
+
+module.exports = skip;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,1992 @@
+{
+  "name": "slash_bot",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "slash_bot",
+      "version": "1.0.0",
+      "license": "ISC",
+      "dependencies": {
+        "@discordjs/voice": "^0.18.0",
+        "@distube/yt-dlp": "^2.0.1",
+        "@distube/ytdl-core": "^4.16.11",
+        "depcheck": "^1.4.7",
+        "discord.js": "^14.19.3",
+        "distube": "^5.0.7",
+        "ffmpeg-static": "^5.2.0",
+        "genius-lyrics": "^4.4.7",
+        "opusscript": "^0.0.8",
+        "play-dl": "^1.9.7",
+        "prism-media": "^1.3.5",
+        "tweetnacl": "^1.0.3"
+      }
+    },
+    "node_modules/@babel/code-frame": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.27.1.tgz",
+      "integrity": "sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg==",
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.27.1",
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/generator": {
+      "version": "7.27.5",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.27.5.tgz",
+      "integrity": "sha512-ZGhA37l0e/g2s1Cnzdix0O3aLYm66eF8aufiVteOgnwxgnRP8GoyMj7VWsgWnQbVKXyge7hqrFh2K2TQM6t1Hw==",
+      "dependencies": {
+        "@babel/parser": "^7.27.5",
+        "@babel/types": "^7.27.3",
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.25",
+        "jsesc": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
+      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.27.1.tgz",
+      "integrity": "sha512-D2hP9eA+Sqx1kBZgzxZh0y1trbuU+JoDkiEwqhQ36nodYqJwyEIhPSdMNd7lOm/4io72luTPWH20Yda0xOuUow==",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.27.5",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.27.5.tgz",
+      "integrity": "sha512-OsQd175SxWkGlzbny8J3K8TnnDD0N3lrIUtB92xwyRpzaenGZhxDvxN/JgU00U3CDZNj9tPuDJ5H0WS4Nt3vKg==",
+      "dependencies": {
+        "@babel/types": "^7.27.3"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/template": {
+      "version": "7.27.2",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.27.2.tgz",
+      "integrity": "sha512-LPDZ85aEJyYSd18/DkjNh4/y1ntkE5KwUHWTiqgRxruuZL2F1yuHligVHLvcHY2vMHXttKFpJn6LwfI7cw7ODw==",
+      "dependencies": {
+        "@babel/code-frame": "^7.27.1",
+        "@babel/parser": "^7.27.2",
+        "@babel/types": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/traverse": {
+      "version": "7.27.4",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.27.4.tgz",
+      "integrity": "sha512-oNcu2QbHqts9BtOWJosOVJapWjBDSxGCpFvikNR5TGDYDQf3JwpIoMzIKrvfoti93cLfPJEG4tH9SPVeyCGgdA==",
+      "dependencies": {
+        "@babel/code-frame": "^7.27.1",
+        "@babel/generator": "^7.27.3",
+        "@babel/parser": "^7.27.4",
+        "@babel/template": "^7.27.2",
+        "@babel/types": "^7.27.3",
+        "debug": "^4.3.1",
+        "globals": "^11.1.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.27.3",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.27.3.tgz",
+      "integrity": "sha512-Y1GkI4ktrtvmawoSq+4FCVHNryea6uR+qUQy0AGxLSsjCX0nVmkYQMBLHDkXZuo5hGx7eYdnIaslsdBFm7zbUw==",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.27.1",
+        "@babel/helper-validator-identifier": "^7.27.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@derhuerst/http-basic": {
+      "version": "8.2.4",
+      "resolved": "https://registry.npmjs.org/@derhuerst/http-basic/-/http-basic-8.2.4.tgz",
+      "integrity": "sha512-F9rL9k9Xjf5blCz8HsJRO4diy111cayL2vkY2XE4r4t3n0yPXVYy3KD3nJ1qbrSn9743UWSXH4IwuCa/HWlGFw==",
+      "dependencies": {
+        "caseless": "^0.12.0",
+        "concat-stream": "^2.0.0",
+        "http-response-object": "^3.0.1",
+        "parse-cache-control": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@discordjs/builders": {
+      "version": "1.11.2",
+      "resolved": "https://registry.npmjs.org/@discordjs/builders/-/builders-1.11.2.tgz",
+      "integrity": "sha512-F1WTABdd8/R9D1icJzajC4IuLyyS8f3rTOz66JsSI3pKvpCAtsMBweu8cyNYsIyvcrKAVn9EPK+Psoymq+XC0A==",
+      "dependencies": {
+        "@discordjs/formatters": "^0.6.1",
+        "@discordjs/util": "^1.1.1",
+        "@sapphire/shapeshift": "^4.0.0",
+        "discord-api-types": "^0.38.1",
+        "fast-deep-equal": "^3.1.3",
+        "ts-mixer": "^6.0.4",
+        "tslib": "^2.6.3"
+      },
+      "engines": {
+        "node": ">=16.11.0"
+      },
+      "funding": {
+        "url": "https://github.com/discordjs/discord.js?sponsor"
+      }
+    },
+    "node_modules/@discordjs/builders/node_modules/discord-api-types": {
+      "version": "0.38.10",
+      "resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.38.10.tgz",
+      "integrity": "sha512-6F02RttmlDoTpFEeOlF1Z9lmNDUFum4ewBPFFjkD6mIlnd+NJ6oze/dllPdp8dpNvFuLHyEfVy+UPZ1s+IWmmA=="
+    },
+    "node_modules/@discordjs/collection": {
+      "version": "1.5.3",
+      "resolved": "https://registry.npmjs.org/@discordjs/collection/-/collection-1.5.3.tgz",
+      "integrity": "sha512-SVb428OMd3WO1paV3rm6tSjM4wC+Kecaa1EUGX7vc6/fddvw/6lg90z4QtCqm21zvVe92vMMDt9+DkIvjXImQQ==",
+      "engines": {
+        "node": ">=16.11.0"
+      }
+    },
+    "node_modules/@discordjs/formatters": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/@discordjs/formatters/-/formatters-0.6.1.tgz",
+      "integrity": "sha512-5cnX+tASiPCqCWtFcFslxBVUaCetB0thvM/JyavhbXInP1HJIEU+Qv/zMrnuwSsX3yWH2lVXNJZeDK3EiP4HHg==",
+      "dependencies": {
+        "discord-api-types": "^0.38.1"
+      },
+      "engines": {
+        "node": ">=16.11.0"
+      },
+      "funding": {
+        "url": "https://github.com/discordjs/discord.js?sponsor"
+      }
+    },
+    "node_modules/@discordjs/formatters/node_modules/discord-api-types": {
+      "version": "0.38.10",
+      "resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.38.10.tgz",
+      "integrity": "sha512-6F02RttmlDoTpFEeOlF1Z9lmNDUFum4ewBPFFjkD6mIlnd+NJ6oze/dllPdp8dpNvFuLHyEfVy+UPZ1s+IWmmA=="
+    },
+    "node_modules/@discordjs/rest": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/@discordjs/rest/-/rest-2.5.0.tgz",
+      "integrity": "sha512-PWhchxTzpn9EV3vvPRpwS0EE2rNYB9pvzDU/eLLW3mByJl0ZHZjHI2/wA8EbH2gRMQV7nu+0FoDF84oiPl8VAQ==",
+      "dependencies": {
+        "@discordjs/collection": "^2.1.1",
+        "@discordjs/util": "^1.1.1",
+        "@sapphire/async-queue": "^1.5.3",
+        "@sapphire/snowflake": "^3.5.3",
+        "@vladfrangu/async_event_emitter": "^2.4.6",
+        "discord-api-types": "^0.38.1",
+        "magic-bytes.js": "^1.10.0",
+        "tslib": "^2.6.3",
+        "undici": "6.21.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/discordjs/discord.js?sponsor"
+      }
+    },
+    "node_modules/@discordjs/rest/node_modules/@discordjs/collection": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@discordjs/collection/-/collection-2.1.1.tgz",
+      "integrity": "sha512-LiSusze9Tc7qF03sLCujF5iZp7K+vRNEDBZ86FT9aQAv3vxMLihUvKvpsCWiQ2DJq1tVckopKm1rxomgNUc9hg==",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/discordjs/discord.js?sponsor"
+      }
+    },
+    "node_modules/@discordjs/rest/node_modules/discord-api-types": {
+      "version": "0.38.10",
+      "resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.38.10.tgz",
+      "integrity": "sha512-6F02RttmlDoTpFEeOlF1Z9lmNDUFum4ewBPFFjkD6mIlnd+NJ6oze/dllPdp8dpNvFuLHyEfVy+UPZ1s+IWmmA=="
+    },
+    "node_modules/@discordjs/rest/node_modules/undici": {
+      "version": "6.21.1",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.21.1.tgz",
+      "integrity": "sha512-q/1rj5D0/zayJB2FraXdaWxbhWiNKDvu8naDT2dl1yTlvJp4BLtOcp2a5BvgGNQpYYJzau7tf1WgKv3b+7mqpQ==",
+      "engines": {
+        "node": ">=18.17"
+      }
+    },
+    "node_modules/@discordjs/util": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@discordjs/util/-/util-1.1.1.tgz",
+      "integrity": "sha512-eddz6UnOBEB1oITPinyrB2Pttej49M9FZQY8NxgEvc3tq6ZICZ19m70RsmzRdDHk80O9NoYN/25AqJl8vPVf/g==",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/discordjs/discord.js?sponsor"
+      }
+    },
+    "node_modules/@discordjs/voice": {
+      "version": "0.18.0",
+      "integrity": "sha512-BvX6+VJE5/vhD9azV9vrZEt9hL1G+GlOdsQaVl5iv9n87fkXjf3cSwllhR3GdaUC8m6dqT8umXIWtn3yCu4afg==",
+      "dependencies": {
+        "@types/ws": "^8.5.12",
+        "discord-api-types": "^0.37.103",
+        "prism-media": "^1.3.5",
+        "tslib": "^2.6.3",
+        "ws": "^8.18.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/discordjs/discord.js?sponsor"
+      }
+    },
+    "node_modules/@discordjs/ws": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@discordjs/ws/-/ws-1.2.2.tgz",
+      "integrity": "sha512-dyfq7yn0wO0IYeYOs3z79I6/HumhmKISzFL0Z+007zQJMtAFGtt3AEoq1nuLXtcunUE5YYYQqgKvybXukAK8/w==",
+      "dependencies": {
+        "@discordjs/collection": "^2.1.0",
+        "@discordjs/rest": "^2.5.0",
+        "@discordjs/util": "^1.1.0",
+        "@sapphire/async-queue": "^1.5.2",
+        "@types/ws": "^8.5.10",
+        "@vladfrangu/async_event_emitter": "^2.2.4",
+        "discord-api-types": "^0.38.1",
+        "tslib": "^2.6.2",
+        "ws": "^8.17.0"
+      },
+      "engines": {
+        "node": ">=16.11.0"
+      },
+      "funding": {
+        "url": "https://github.com/discordjs/discord.js?sponsor"
+      }
+    },
+    "node_modules/@discordjs/ws/node_modules/@discordjs/collection": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@discordjs/collection/-/collection-2.1.1.tgz",
+      "integrity": "sha512-LiSusze9Tc7qF03sLCujF5iZp7K+vRNEDBZ86FT9aQAv3vxMLihUvKvpsCWiQ2DJq1tVckopKm1rxomgNUc9hg==",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/discordjs/discord.js?sponsor"
+      }
+    },
+    "node_modules/@discordjs/ws/node_modules/discord-api-types": {
+      "version": "0.38.10",
+      "resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.38.10.tgz",
+      "integrity": "sha512-6F02RttmlDoTpFEeOlF1Z9lmNDUFum4ewBPFFjkD6mIlnd+NJ6oze/dllPdp8dpNvFuLHyEfVy+UPZ1s+IWmmA=="
+    },
+    "node_modules/@distube/yt-dlp": {
+      "version": "2.0.1",
+      "integrity": "sha512-9c16lRU6jbyal38UUr5E36+2lp36s0DaJySOtFjuAPgaJkp2xvKvyd+s4rFZSqVQGJO5GOhBiH+HD115SKfKAw==",
+      "hasInstallScript": true,
+      "dependencies": {
+        "dargs": "^7.0.0",
+        "undici": "^6.18.2"
+      },
+      "funding": {
+        "url": "https://github.com/skick1234/DisTube?sponsor"
+      },
+      "peerDependencies": {
+        "distube": "5"
+      }
+    },
+    "node_modules/@distube/yt-dlp/node_modules/undici": {
+      "version": "6.21.3",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.21.3.tgz",
+      "integrity": "sha512-gBLkYIlEnSp8pFbT64yFgGE6UIB9tAkhukC23PmMDCe5Nd+cRqKxSjw5y54MK2AZMgZfJWMaNE4nYUHgi1XEOw==",
+      "engines": {
+        "node": ">=18.17"
+      }
+    },
+    "node_modules/@distube/ytdl-core": {
+      "version": "4.16.11",
+      "resolved": "https://registry.npmjs.org/@distube/ytdl-core/-/ytdl-core-4.16.11.tgz",
+      "integrity": "sha512-yMQiicS5CuuTBsROb1iCRM09VZVL98EJ40LEtC7dMrgOWaHuJIwaL1w/ddC9DTNOUEV90T/1xYYLqM6Oc7q9kQ==",
+      "license": "MIT",
+      "dependencies": {
+        "http-cookie-agent": "^7.0.1",
+        "https-proxy-agent": "^7.0.6",
+        "m3u8stream": "^0.8.6",
+        "miniget": "^4.2.3",
+        "sax": "^1.4.1",
+        "tough-cookie": "^5.1.2",
+        "undici": "^7.8.0"
+      },
+      "engines": {
+        "node": ">=20.18.1"
+      },
+      "funding": {
+        "url": "https://github.com/distubejs/ytdl-core?sponsor"
+      }
+    },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.8",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.8.tgz",
+      "integrity": "sha512-imAbBGkb+ebQyxKgzv5Hu2nmROxoDOXHh80evxdoXNOrvAnVx7zimzc1Oo5h9RlfV4vPXaE2iM5pOFbvOCClWA==",
+      "dependencies": {
+        "@jridgewell/set-array": "^1.2.1",
+        "@jridgewell/sourcemap-codec": "^1.4.10",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/set-array": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@jridgewell/set-array/-/set-array-1.2.1.tgz",
+      "integrity": "sha512-R8gLRTZeyp03ymzP/6Lil/28tGeGEzhx1q2k703KGWRAI1VdvPIXdG70VJc2pAMw3NA6JKL5hhFu1sJX0Mnn/A==",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.0.tgz",
+      "integrity": "sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ=="
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.25",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.25.tgz",
+      "integrity": "sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ==",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@sapphire/async-queue": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@sapphire/async-queue/-/async-queue-1.5.5.tgz",
+      "integrity": "sha512-cvGzxbba6sav2zZkH8GPf2oGk9yYoD5qrNWdu9fRehifgnFZJMV+nuy2nON2roRO4yQQ+v7MK/Pktl/HgfsUXg==",
+      "engines": {
+        "node": ">=v14.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@sapphire/shapeshift": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@sapphire/shapeshift/-/shapeshift-4.0.0.tgz",
+      "integrity": "sha512-d9dUmWVA7MMiKobL3VpLF8P2aeanRTu6ypG2OIaEv/ZHH/SUQ2iHOVyi5wAPjQ+HmnMuL0whK9ez8I/raWbtIg==",
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "lodash": "^4.17.21"
+      },
+      "engines": {
+        "node": ">=v16"
+      }
+    },
+    "node_modules/@sapphire/snowflake": {
+      "version": "3.5.3",
+      "resolved": "https://registry.npmjs.org/@sapphire/snowflake/-/snowflake-3.5.3.tgz",
+      "integrity": "sha512-jjmJywLAFoWeBi1W7994zZyiNWPIiqRRNAmSERxyg93xRGzNYvGjlZ0gR6x0F4gPRi2+0O6S71kOZYyr3cxaIQ==",
+      "engines": {
+        "node": ">=v14.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@types/minimatch": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.5.tgz",
+      "integrity": "sha512-Klz949h02Gz2uZCMGwDUSDS1YBlTdDDgbWHi+81l29tQALUtvz4rAYi5uoVhE5Lagoq6DeqAUlbrHvW/mXDgdQ=="
+    },
+    "node_modules/@types/node": {
+      "version": "22.15.29",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.15.29.tgz",
+      "integrity": "sha512-LNdjOkUDlU1RZb8e1kOIUpN1qQUlzGkEtbVNo53vbrwDg5om6oduhm4SiUaPW5ASTXhAiP0jInWG8Qx9fVlOeQ==",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@types/parse-json": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.2.tgz",
+      "integrity": "sha512-dISoDXWWQwUquiKsyZ4Ng+HX2KsPL7LyHKHQwgGFEA3IaKac4Obd+h2a/a6waisAoepJlBcx9paWqjA8/HVjCw=="
+    },
+    "node_modules/@types/ws": {
+      "version": "8.18.1",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.18.1.tgz",
+      "integrity": "sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@vladfrangu/async_event_emitter": {
+      "version": "2.4.6",
+      "resolved": "https://registry.npmjs.org/@vladfrangu/async_event_emitter/-/async_event_emitter-2.4.6.tgz",
+      "integrity": "sha512-RaI5qZo6D2CVS6sTHFKg1v5Ohq/+Bo2LZ5gzUEwZ/WkHhwtGTCB/sVLw8ijOkAUxasZ+WshN/Rzj4ywsABJ5ZA==",
+      "engines": {
+        "node": ">=v14.0.0",
+        "npm": ">=7.0.0"
+      }
+    },
+    "node_modules/@vue/compiler-core": {
+      "version": "3.5.16",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.5.16.tgz",
+      "integrity": "sha512-AOQS2eaQOaaZQoL1u+2rCJIKDruNXVBZSiUD3chnUrsoX5ZTQMaCvXlWNIfxBJuU15r1o7+mpo5223KVtIhAgQ==",
+      "dependencies": {
+        "@babel/parser": "^7.27.2",
+        "@vue/shared": "3.5.16",
+        "entities": "^4.5.0",
+        "estree-walker": "^2.0.2",
+        "source-map-js": "^1.2.1"
+      }
+    },
+    "node_modules/@vue/compiler-dom": {
+      "version": "3.5.16",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.5.16.tgz",
+      "integrity": "sha512-SSJIhBr/teipXiXjmWOVWLnxjNGo65Oj/8wTEQz0nqwQeP75jWZ0n4sF24Zxoht1cuJoWopwj0J0exYwCJ0dCQ==",
+      "dependencies": {
+        "@vue/compiler-core": "3.5.16",
+        "@vue/shared": "3.5.16"
+      }
+    },
+    "node_modules/@vue/compiler-sfc": {
+      "version": "3.5.16",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.5.16.tgz",
+      "integrity": "sha512-rQR6VSFNpiinDy/DVUE0vHoIDUF++6p910cgcZoaAUm3POxgNOOdS/xgoll3rNdKYTYPnnbARDCZOyZ+QSe6Pw==",
+      "dependencies": {
+        "@babel/parser": "^7.27.2",
+        "@vue/compiler-core": "3.5.16",
+        "@vue/compiler-dom": "3.5.16",
+        "@vue/compiler-ssr": "3.5.16",
+        "@vue/shared": "3.5.16",
+        "estree-walker": "^2.0.2",
+        "magic-string": "^0.30.17",
+        "postcss": "^8.5.3",
+        "source-map-js": "^1.2.1"
+      }
+    },
+    "node_modules/@vue/compiler-ssr": {
+      "version": "3.5.16",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.5.16.tgz",
+      "integrity": "sha512-d2V7kfxbdsjrDSGlJE7my1ZzCXViEcqN6w14DOsDrUCHEA6vbnVCpRFfrc4ryCP/lCKzX2eS1YtnLE/BuC9f/A==",
+      "dependencies": {
+        "@vue/compiler-dom": "3.5.16",
+        "@vue/shared": "3.5.16"
+      }
+    },
+    "node_modules/@vue/shared": {
+      "version": "3.5.16",
+      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.5.16.tgz",
+      "integrity": "sha512-c/0fWy3Jw6Z8L9FmTyYfkpM5zklnqqa9+a6dz3DvONRKW2NEbh46BP0FHuLFSWi2TnQEtp91Z6zOWNrU6QiyPg=="
+    },
+    "node_modules/agent-base": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.3.tgz",
+      "integrity": "sha512-jRR5wdylq8CkOe6hei19GGZnxM6rBGwFl3Bg0YItGDimvjGtAvdZk4Pu6Cl4u4Igsws4a1fd1Vq3ezrhn4KmFw==",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "dependencies": {
+        "sprintf-js": "~1.0.2"
+      }
+    },
+    "node_modules/array-differ": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/array-differ/-/array-differ-3.0.0.tgz",
+      "integrity": "sha512-THtfYS6KtME/yIAhKjZ2ul7XI96lQGHRputJQHO80LAWQnuGP4iCIN8vdMRboGbIEYBwU33q8Tch1os2+X0kMg==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/array-union": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
+      "integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/arrify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/arrify/-/arrify-2.0.1.tgz",
+      "integrity": "sha512-3duEwti880xqi4eAMN8AyR4a0ByT90zoYdLlevfrvU43vb0YZwZVfxOgxWrLXXXpyugL0hNZc9G6BiB5B3nUug==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="
+    },
+    "node_modules/boolbase": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
+      "integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww=="
+    },
+    "node_modules/brace-expansion": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.0.1.tgz",
+      "integrity": "sha512-XnAIvQ8eM+kC6aULx6wuQiwVsnzsi9d3WxzV3FpWTGA19F621kwdbsAcFKXgKUHZWsy+mY6iL1sHTxWEFCytDA==",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/braces": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
+      "dependencies": {
+        "fill-range": "^7.1.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/buffer-from": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
+      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ=="
+    },
+    "node_modules/callsite": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/callsite/-/callsite-1.0.0.tgz",
+      "integrity": "sha512-0vdNRFXn5q+dtOqjfFtmtlI9N2eVZ7LMyEV2iKC5mEEFvSg/69Ml6b/WU2qF8W1nLRa0wiSrDT3Y5jOHZCwKPQ==",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/callsites": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
+      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/camelcase": {
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
+      "integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/caseless": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
+      "integrity": "sha512-4tYFyifaFfGacoiObjJegolkwSU4xQNGbVgUiNYVUxbQ2x2lUsFvY4hVgVzGiIe6WLOPqycWXA40l+PWsxthUw=="
+    },
+    "node_modules/cliui": {
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-7.0.4.tgz",
+      "integrity": "sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.0",
+        "wrap-ansi": "^7.0.0"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+    },
+    "node_modules/concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg=="
+    },
+    "node_modules/concat-stream": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-2.0.0.tgz",
+      "integrity": "sha512-MWufYdFw53ccGjCA+Ol7XJYpAlW6/prSMzuPOTRnJGcGzuhLn4Scrz7qf6o8bROZ514ltazcIFJZevcfbo0x7A==",
+      "engines": [
+        "node >= 6.0"
+      ],
+      "dependencies": {
+        "buffer-from": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.0.2",
+        "typedarray": "^0.0.6"
+      }
+    },
+    "node_modules/cosmiconfig": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.1.0.tgz",
+      "integrity": "sha512-AdmX6xUzdNASswsFtmwSt7Vj8po9IuqXm0UXz7QKPuEUmPB4XyjGfaAr2PSuELMwkRMVH1EpIkX5bTZGRB3eCA==",
+      "dependencies": {
+        "@types/parse-json": "^4.0.0",
+        "import-fresh": "^3.2.1",
+        "parse-json": "^5.0.0",
+        "path-type": "^4.0.0",
+        "yaml": "^1.10.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/css-select": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/css-select/-/css-select-5.1.0.tgz",
+      "integrity": "sha512-nwoRF1rvRRnnCqqY7updORDsuqKzqYJ28+oSMaJMMgOauh3fvwHqMS7EZpIPqK8GL+g9mKxF1vP/ZjSeNjEVHg==",
+      "dependencies": {
+        "boolbase": "^1.0.0",
+        "css-what": "^6.1.0",
+        "domhandler": "^5.0.2",
+        "domutils": "^3.0.1",
+        "nth-check": "^2.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
+    "node_modules/css-what": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/css-what/-/css-what-6.1.0.tgz",
+      "integrity": "sha512-HTUrgRJ7r4dsZKU6GjmpfRK1O76h97Z8MfS1G0FozR+oF2kG6Vfe8JE6zwrkbxigziPHinCJ+gCPjA9EaBDtRw==",
+      "engines": {
+        "node": ">= 6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/fb55"
+      }
+    },
+    "node_modules/dargs": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/dargs/-/dargs-7.0.0.tgz",
+      "integrity": "sha512-2iy1EkLdlBzQGvbweYRFxmFath8+K7+AKB0TlhHWkNuH+TmovaMH/Wp7V7R4u7f4SnX3OgLsU9t1NI9ioDnUpg==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
+      "integrity": "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/depcheck": {
+      "version": "1.4.7",
+      "resolved": "https://registry.npmjs.org/depcheck/-/depcheck-1.4.7.tgz",
+      "integrity": "sha512-1lklS/bV5chOxwNKA/2XUUk/hPORp8zihZsXflr8x0kLwmcZ9Y9BsS6Hs3ssvA+2wUVbG0U2Ciqvm1SokNjPkA==",
+      "dependencies": {
+        "@babel/parser": "^7.23.0",
+        "@babel/traverse": "^7.23.2",
+        "@vue/compiler-sfc": "^3.3.4",
+        "callsite": "^1.0.0",
+        "camelcase": "^6.3.0",
+        "cosmiconfig": "^7.1.0",
+        "debug": "^4.3.4",
+        "deps-regex": "^0.2.0",
+        "findup-sync": "^5.0.0",
+        "ignore": "^5.2.4",
+        "is-core-module": "^2.12.0",
+        "js-yaml": "^3.14.1",
+        "json5": "^2.2.3",
+        "lodash": "^4.17.21",
+        "minimatch": "^7.4.6",
+        "multimatch": "^5.0.0",
+        "please-upgrade-node": "^3.2.0",
+        "readdirp": "^3.6.0",
+        "require-package-name": "^2.0.1",
+        "resolve": "^1.22.3",
+        "resolve-from": "^5.0.0",
+        "semver": "^7.5.4",
+        "yargs": "^16.2.0"
+      },
+      "bin": {
+        "depcheck": "bin/depcheck.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/deps-regex": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/deps-regex/-/deps-regex-0.2.0.tgz",
+      "integrity": "sha512-PwuBojGMQAYbWkMXOY9Pd/NWCDNHVH12pnS7WHqZkTSeMESe4hwnKKRp0yR87g37113x4JPbo/oIvXY+s/f56Q=="
+    },
+    "node_modules/detect-file": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/detect-file/-/detect-file-1.0.0.tgz",
+      "integrity": "sha512-DtCOLG98P007x7wiiOmfI0fi3eIKyWiLTGJ2MDnVi/E04lWGbf+JzrRHMm0rgIIZJGtHpKpbVgLWHrv8xXpc3Q==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/discord-api-types": {
+      "version": "0.37.120",
+      "resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.37.120.tgz",
+      "integrity": "sha512-7xpNK0EiWjjDFp2nAhHXezE4OUWm7s1zhc/UXXN6hnFFU8dfoPHgV0Hx0RPiCa3ILRpdeh152icc68DGCyXYIw=="
+    },
+    "node_modules/discord.js": {
+      "version": "14.19.3",
+      "integrity": "sha512-lncTRk0k+8Q5D3nThnODBR8fR8x2fM798o8Vsr40Krx0DjPwpZCuxxTcFMrXMQVOqM1QB9wqWgaXPg3TbmlHqA==",
+      "dependencies": {
+        "@discordjs/builders": "^1.11.2",
+        "@discordjs/collection": "1.5.3",
+        "@discordjs/formatters": "^0.6.1",
+        "@discordjs/rest": "^2.5.0",
+        "@discordjs/util": "^1.1.1",
+        "@discordjs/ws": "^1.2.2",
+        "@sapphire/snowflake": "3.5.3",
+        "discord-api-types": "^0.38.1",
+        "fast-deep-equal": "3.1.3",
+        "lodash.snakecase": "4.1.1",
+        "magic-bytes.js": "^1.10.0",
+        "tslib": "^2.6.3",
+        "undici": "6.21.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/discordjs/discord.js?sponsor"
+      }
+    },
+    "node_modules/discord.js/node_modules/discord-api-types": {
+      "version": "0.38.8",
+      "resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.38.8.tgz",
+      "integrity": "sha512-xuRXPD44FcbKHrQK15FS1HFlMRNJtsaZou/SVws18vQ7zHqmlxyDktMkZpyvD6gE2ctGOVYC/jUyoMMAyBWfcw=="
+    },
+    "node_modules/discord.js/node_modules/undici": {
+      "version": "6.21.1",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.21.1.tgz",
+      "integrity": "sha512-q/1rj5D0/zayJB2FraXdaWxbhWiNKDvu8naDT2dl1yTlvJp4BLtOcp2a5BvgGNQpYYJzau7tf1WgKv3b+7mqpQ==",
+      "engines": {
+        "node": ">=18.17"
+      }
+    },
+    "node_modules/distube": {
+      "version": "5.0.7",
+      "integrity": "sha512-EyxXH2q+SGIgdtKgDPaGvQe9Tyce7nMfps6FV1mt6EUDQg1ld1I2NrLsugCUHaelDpG7zG950dFvv6xryRnMuA==",
+      "dependencies": {
+        "tiny-typed-emitter": "^2.1.0",
+        "undici": "^7.7.0"
+      },
+      "engines": {
+        "node": ">=18.17"
+      },
+      "funding": {
+        "url": "https://github.com/skick1234/DisTube?sponsor"
+      },
+      "peerDependencies": {
+        "@discordjs/voice": "*",
+        "discord.js": "14"
+      }
+    },
+    "node_modules/dom-serializer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
+      "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
+      "dependencies": {
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.2",
+        "entities": "^4.2.0"
+      },
+      "funding": {
+        "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
+      }
+    },
+    "node_modules/domelementtype": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
+      "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ]
+    },
+    "node_modules/domhandler": {
+      "version": "5.0.3",
+      "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
+      "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
+      "dependencies": {
+        "domelementtype": "^2.3.0"
+      },
+      "engines": {
+        "node": ">= 4"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domhandler?sponsor=1"
+      }
+    },
+    "node_modules/domutils": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.2.2.tgz",
+      "integrity": "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==",
+      "dependencies": {
+        "dom-serializer": "^2.0.0",
+        "domelementtype": "^2.3.0",
+        "domhandler": "^5.0.3"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/domutils?sponsor=1"
+      }
+    },
+    "node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
+    },
+    "node_modules/entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/env-paths": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz",
+      "integrity": "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/error-ex": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
+      "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
+      "dependencies": {
+        "is-arrayish": "^0.2.1"
+      }
+    },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/esprima": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+      "bin": {
+        "esparse": "bin/esparse.js",
+        "esvalidate": "bin/esvalidate.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
+      "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w=="
+    },
+    "node_modules/expand-tilde": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/expand-tilde/-/expand-tilde-2.0.2.tgz",
+      "integrity": "sha512-A5EmesHW6rfnZ9ysHQjPdJRni0SRar0tjtG5MNtm9n5TUvsYU8oozprtRD4AqHxcZWWlVuAmQo2nWKfN9oyjTw==",
+      "dependencies": {
+        "homedir-polyfill": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
+    },
+    "node_modules/ffmpeg-static": {
+      "version": "5.2.0",
+      "integrity": "sha512-WrM7kLW+do9HLr+H6tk7LzQ7kPqbAgLjdzNE32+u3Ff11gXt9Kkkd2nusGFrlWMIe+XaA97t+I8JS7sZIrvRgA==",
+      "hasInstallScript": true,
+      "dependencies": {
+        "@derhuerst/http-basic": "^8.2.0",
+        "env-paths": "^2.2.0",
+        "https-proxy-agent": "^5.0.0",
+        "progress": "^2.0.3"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/ffmpeg-static/node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/ffmpeg-static/node_modules/https-proxy-agent": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "dependencies": {
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/fill-range": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
+      "dependencies": {
+        "to-regex-range": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/findup-sync": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-5.0.0.tgz",
+      "integrity": "sha512-MzwXju70AuyflbgeOhzvQWAvvQdo1XL0A9bVvlXsYcFEBM87WR4OakL4OfZq+QRmr+duJubio+UtNQCPsVESzQ==",
+      "dependencies": {
+        "detect-file": "^1.0.0",
+        "is-glob": "^4.0.3",
+        "micromatch": "^4.0.4",
+        "resolve-dir": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 10.13.0"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/genius-lyrics": {
+      "version": "4.4.7",
+      "integrity": "sha512-cgO5nSeFqtLZAUyWB+8XWMRBIRzPUSUC42N3CoDGRgKX1anGAyDUhM6/RVIJXCNnQa6XHZHswKcKgHaRiyl+GQ==",
+      "dependencies": {
+        "node-html-parser": "^6.1.13",
+        "undici": "^6.11.1"
+      }
+    },
+    "node_modules/genius-lyrics/node_modules/undici": {
+      "version": "6.21.3",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.21.3.tgz",
+      "integrity": "sha512-gBLkYIlEnSp8pFbT64yFgGE6UIB9tAkhukC23PmMDCe5Nd+cRqKxSjw5y54MK2AZMgZfJWMaNE4nYUHgi1XEOw==",
+      "engines": {
+        "node": ">=18.17"
+      }
+    },
+    "node_modules/get-caller-file": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
+      "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
+      "engines": {
+        "node": "6.* || 8.* || >= 10.*"
+      }
+    },
+    "node_modules/global-modules": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/global-modules/-/global-modules-1.0.0.tgz",
+      "integrity": "sha512-sKzpEkf11GpOFuw0Zzjzmt4B4UZwjOcG757PPvrfhxcLFbq0wpsgpOqxpxtxFiCG4DtG93M6XRVbF2oGdev7bg==",
+      "dependencies": {
+        "global-prefix": "^1.0.1",
+        "is-windows": "^1.0.1",
+        "resolve-dir": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/global-prefix": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/global-prefix/-/global-prefix-1.0.2.tgz",
+      "integrity": "sha512-5lsx1NUDHtSjfg0eHlmYvZKv8/nVqX4ckFbM+FrGcQ+04KWcWFo9P5MxPZYSzUvyzmdTbI7Eix8Q4IbELDqzKg==",
+      "dependencies": {
+        "expand-tilde": "^2.0.2",
+        "homedir-polyfill": "^1.0.1",
+        "ini": "^1.3.4",
+        "is-windows": "^1.0.1",
+        "which": "^1.2.14"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/global-prefix/node_modules/which": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+      "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "which": "bin/which"
+      }
+    },
+    "node_modules/globals": {
+      "version": "11.12.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
+      "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/he": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
+      "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
+      "bin": {
+        "he": "bin/he"
+      }
+    },
+    "node_modules/homedir-polyfill": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/homedir-polyfill/-/homedir-polyfill-1.0.3.tgz",
+      "integrity": "sha512-eSmmWE5bZTK2Nou4g0AI3zZ9rswp7GRKoKXS1BLUkvPviOqs4YTN1djQIqrXy9k5gEtdLPy86JjRwsNM9tnDcA==",
+      "dependencies": {
+        "parse-passwd": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/http-cookie-agent": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/http-cookie-agent/-/http-cookie-agent-7.0.1.tgz",
+      "integrity": "sha512-lZHFZUdPTw64PdksQac5xbUd4NWjUbyDYnvR//2sbLpcC4UqEUW0x/6O+rDntVzJzJ07QvhtL5XZSC+c5EK+IQ==",
+      "dependencies": {
+        "agent-base": "^7.1.3"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/3846masa"
+      },
+      "peerDependencies": {
+        "tough-cookie": "^4.0.0 || ^5.0.0",
+        "undici": "^7.0.0"
+      },
+      "peerDependenciesMeta": {
+        "undici": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/http-response-object": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/http-response-object/-/http-response-object-3.0.2.tgz",
+      "integrity": "sha512-bqX0XTF6fnXSQcEJ2Iuyr75yVakyjIDCqroJQ/aHfSdlM743Cwqoi2nDYMzLGWUcuTWGWy8AAvOKXTfiv6q9RA==",
+      "dependencies": {
+        "@types/node": "^10.0.3"
+      }
+    },
+    "node_modules/http-response-object/node_modules/@types/node": {
+      "version": "10.17.60",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.60.tgz",
+      "integrity": "sha512-F0KIgDJfy2nA3zMLmWGKxcH2ZVEtCZXHHdOQs2gSaQ27+lNeEfGxzkIw90aXswATX7AZ33tahPbzy6KAfUreVw=="
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/ignore": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
+      "integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/import-fresh": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
+      "integrity": "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==",
+      "dependencies": {
+        "parent-module": "^1.0.0",
+        "resolve-from": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/import-fresh/node_modules/resolve-from": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+      "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+    },
+    "node_modules/ini": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew=="
+    },
+    "node_modules/is-arrayish": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+      "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg=="
+    },
+    "node_modules/is-core-module": {
+      "version": "2.16.1",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.1.tgz",
+      "integrity": "sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==",
+      "dependencies": {
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "dependencies": {
+        "is-extglob": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-number": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "engines": {
+        "node": ">=0.12.0"
+      }
+    },
+    "node_modules/is-windows": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
+      "integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="
+    },
+    "node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
+    },
+    "node_modules/js-yaml": {
+      "version": "3.14.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.1.tgz",
+      "integrity": "sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==",
+      "dependencies": {
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/jsesc": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
+      "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
+      "bin": {
+        "jsesc": "bin/jsesc"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/json-parse-even-better-errors": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
+      "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w=="
+    },
+    "node_modules/json5": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+      "bin": {
+        "json5": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/lines-and-columns": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
+      "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg=="
+    },
+    "node_modules/lodash": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+    },
+    "node_modules/lodash.snakecase": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lodash.snakecase/-/lodash.snakecase-4.1.1.tgz",
+      "integrity": "sha512-QZ1d4xoBHYUeuouhEq3lk3Uq7ldgyFXGBhg04+oRLnIz8o9T65Eh+8YdroUwn846zchkA9yDsDl5CVVaV2nqYw=="
+    },
+    "node_modules/m3u8stream": {
+      "version": "0.8.6",
+      "resolved": "https://registry.npmjs.org/m3u8stream/-/m3u8stream-0.8.6.tgz",
+      "integrity": "sha512-LZj8kIVf9KCphiHmH7sbFQTVe4tOemb202fWwvJwR9W5ENW/1hxJN6ksAWGhQgSBSa3jyWhnjKU1Fw1GaOdbyA==",
+      "dependencies": {
+        "miniget": "^4.2.2",
+        "sax": "^1.2.4"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/magic-bytes.js": {
+      "version": "1.12.1",
+      "resolved": "https://registry.npmjs.org/magic-bytes.js/-/magic-bytes.js-1.12.1.tgz",
+      "integrity": "sha512-ThQLOhN86ZkJ7qemtVRGYM+gRgR8GEXNli9H/PMvpnZsE44Xfh3wx9kGJaldg314v85m+bFW6WBMaVHJc/c3zA=="
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.17",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.17.tgz",
+      "integrity": "sha512-sNPKHvyjVf7gyjwS4xGTaW/mCnF8wnjtifKBEhxfZ7E/S8tQ0rssrwGNn6q8JH/ohItJfSQp9mBtQYuTlH5QnA==",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0"
+      }
+    },
+    "node_modules/micromatch": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
+      "dependencies": {
+        "braces": "^3.0.3",
+        "picomatch": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=8.6"
+      }
+    },
+    "node_modules/miniget": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/miniget/-/miniget-4.2.3.tgz",
+      "integrity": "sha512-SjbDPDICJ1zT+ZvQwK0hUcRY4wxlhhNpHL9nJOB2MEAXRGagTljsO8MEDzQMTFf0Q8g4QNi8P9lEm/g7e+qgzA==",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "7.4.6",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-7.4.6.tgz",
+      "integrity": "sha512-sBz8G/YjVniEz6lKPNpKxXwazJe4c19fEfV2GDMX6AjFz+MX9uDWIZW8XreVhkFW3fkIdTv/gxWr/Kks5FFAVw==",
+      "dependencies": {
+        "brace-expansion": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
+    },
+    "node_modules/multimatch": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/multimatch/-/multimatch-5.0.0.tgz",
+      "integrity": "sha512-ypMKuglUrZUD99Tk2bUQ+xNQj43lPEfAeX2o9cTteAmShXy2VHDJpuwu1o0xqoKCt9jLVAvwyFKdLTPXKAfJyA==",
+      "dependencies": {
+        "@types/minimatch": "^3.0.3",
+        "array-differ": "^3.0.0",
+        "array-union": "^2.1.0",
+        "arrify": "^2.0.1",
+        "minimatch": "^3.0.4"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/multimatch/node_modules/brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/multimatch/node_modules/minimatch": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/node-html-parser": {
+      "version": "6.1.13",
+      "resolved": "https://registry.npmjs.org/node-html-parser/-/node-html-parser-6.1.13.tgz",
+      "integrity": "sha512-qIsTMOY4C/dAa5Q5vsobRpOOvPfC4pB61UVW2uSwZNUp0QU/jCekTal1vMmbO0DgdHeLUJpv/ARmDqErVxA3Sg==",
+      "dependencies": {
+        "css-select": "^5.1.0",
+        "he": "1.2.0"
+      }
+    },
+    "node_modules/nth-check": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.1.1.tgz",
+      "integrity": "sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==",
+      "dependencies": {
+        "boolbase": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/nth-check?sponsor=1"
+      }
+    },
+    "node_modules/opusscript": {
+      "version": "0.0.8",
+      "integrity": "sha512-VSTi1aWFuCkRCVq+tx/BQ5q9fMnQ9pVZ3JU4UHKqTkf0ED3fKEPdr+gKAAl3IA2hj9rrP6iyq3hlcJq3HELtNQ=="
+    },
+    "node_modules/parent-module": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
+      "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
+      "dependencies": {
+        "callsites": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/parse-cache-control": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/parse-cache-control/-/parse-cache-control-1.0.1.tgz",
+      "integrity": "sha512-60zvsJReQPX5/QP0Kzfd/VrpjScIQ7SHBW6bFCYfEP+fp0Eppr1SHhIO5nd1PjZtvclzSzES9D/p5nFJurwfWg=="
+    },
+    "node_modules/parse-json": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
+      "integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
+      "dependencies": {
+        "@babel/code-frame": "^7.0.0",
+        "error-ex": "^1.3.1",
+        "json-parse-even-better-errors": "^2.3.0",
+        "lines-and-columns": "^1.1.6"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/parse-passwd": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/parse-passwd/-/parse-passwd-1.0.0.tgz",
+      "integrity": "sha512-1Y1A//QUXEZK7YKz+rD9WydcE1+EuPr6ZBgKecAB8tmoW6UFv0NREVJe1p+jRxtThkcbbKkfwIbWJe/IeE6m2Q==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/path-parse": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw=="
+    },
+    "node_modules/path-type": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
+      "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="
+    },
+    "node_modules/picomatch": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/play-audio": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/play-audio/-/play-audio-0.5.2.tgz",
+      "integrity": "sha512-ZAqHUKkQLix2Iga7pPbsf1LpUoBjcpwU93F1l3qBIfxYddQLhxS6GKmS0d3jV8kSVaUbr6NnOEcEMFvuX93SWQ=="
+    },
+    "node_modules/play-dl": {
+      "version": "1.9.7",
+      "integrity": "sha512-KpgerWxUCY4s9Mhze2qdqPhiqd8Ve6HufpH9mBH3FN+vux55qSh6WJKDabfie8IBHN7lnrAlYcT/UdGax58c2A==",
+      "dependencies": {
+        "play-audio": "^0.5.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/please-upgrade-node": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/please-upgrade-node/-/please-upgrade-node-3.2.0.tgz",
+      "integrity": "sha512-gQR3WpIgNIKwBMVLkpMUeR3e1/E1y42bqDQZfql+kDeXd8COYfM8PQA4X6y7a8u9Ua9FHmsrrmirW2vHs45hWg==",
+      "dependencies": {
+        "semver-compare": "^1.0.0"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.4",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.4.tgz",
+      "integrity": "sha512-QSa9EBe+uwlGTFmHsPKokv3B/oEMQZxfqW0QqNCyhpa6mB1afzulwn8hihglqAb2pOw+BJgNlmXQ8la2VeHB7w==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "dependencies": {
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/prism-media": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/prism-media/-/prism-media-1.3.5.tgz",
+      "integrity": "sha512-IQdl0Q01m4LrkN1EGIE9lphov5Hy7WWlH6ulf5QdGePLlPas9p2mhgddTEHrlaXYjjFToM1/rWuwF37VF4taaA==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "@discordjs/opus": ">=0.8.0 <1.0.0",
+        "ffmpeg-static": "^5.0.2 || ^4.2.7 || ^3.0.0 || ^2.4.0",
+        "node-opus": "^0.3.3",
+        "opusscript": "^0.0.8"
+      },
+      "peerDependenciesMeta": {
+        "@discordjs/opus": {
+          "optional": true
+        },
+        "ffmpeg-static": {
+          "optional": true
+        },
+        "node-opus": {
+          "optional": true
+        },
+        "opusscript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/progress": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
+      "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/readdirp": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
+      "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
+      "dependencies": {
+        "picomatch": "^2.2.1"
+      },
+      "engines": {
+        "node": ">=8.10.0"
+      }
+    },
+    "node_modules/require-directory": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
+      "integrity": "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/require-package-name": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/require-package-name/-/require-package-name-2.0.1.tgz",
+      "integrity": "sha512-uuoJ1hU/k6M0779t3VMVIYpb2VMJk05cehCaABFhXaibcbvfgR8wKiozLjVFSzJPmQMRqIcO0HMyTFqfV09V6Q=="
+    },
+    "node_modules/resolve": {
+      "version": "1.22.10",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.10.tgz",
+      "integrity": "sha512-NPRy+/ncIMeDlTAsuqwKIiferiawhefFJtkNSW0qZJEqMEb+qBt/77B/jGeeek+F0uOeN05CDa6HXbbIgtVX4w==",
+      "dependencies": {
+        "is-core-module": "^2.16.0",
+        "path-parse": "^1.0.7",
+        "supports-preserve-symlinks-flag": "^1.0.0"
+      },
+      "bin": {
+        "resolve": "bin/resolve"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/resolve-dir": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/resolve-dir/-/resolve-dir-1.0.1.tgz",
+      "integrity": "sha512-R7uiTjECzvOsWSfdM0QKFNBVFcK27aHOUwdvK53BcW8zqnGdYp0Fbj82cy54+2A4P2tFM22J5kRfe1R+lM/1yg==",
+      "dependencies": {
+        "expand-tilde": "^2.0.0",
+        "global-modules": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/resolve-from": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
+      "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ]
+    },
+    "node_modules/sax": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/sax/-/sax-1.4.1.tgz",
+      "integrity": "sha512-+aWOz7yVScEGoKNd4PA10LZ8sk0A/z5+nXQG5giUO5rprX9jgYsTdov9qCchZiPIZezbZH+jRut8nPodFAX4Jg=="
+    },
+    "node_modules/semver": {
+      "version": "7.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
+      "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/semver-compare": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/semver-compare/-/semver-compare-1.0.0.tgz",
+      "integrity": "sha512-YM3/ITh2MJ5MtzaM429anh+x2jiLVjqILF4m4oyQB18W7Ggea7BfqdH/wGMK7dDiMghv/6WG7znWMwUDzJiXow=="
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/sprintf-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g=="
+    },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
+    "node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/supports-preserve-symlinks-flag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
+      "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/tiny-typed-emitter": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/tiny-typed-emitter/-/tiny-typed-emitter-2.1.0.tgz",
+      "integrity": "sha512-qVtvMxeXbVej0cQWKqVSSAHmKZEHAvxdF8HEUBFWts8h+xEo5m/lEiPakuyZ3BnCBjOD8i24kzNOiOLLgsSxhA=="
+    },
+    "node_modules/tldts": {
+      "version": "6.1.86",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-6.1.86.tgz",
+      "integrity": "sha512-WMi/OQ2axVTf/ykqCQgXiIct+mSQDFdH2fkwhPwgEwvJ1kSzZRiinb0zF2Xb8u4+OqPChmyI6MEu4EezNJz+FQ==",
+      "dependencies": {
+        "tldts-core": "^6.1.86"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "6.1.86",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-6.1.86.tgz",
+      "integrity": "sha512-Je6p7pkk+KMzMv2XXKmAE3McmolOQFdxkKw0R8EYNr7sELW46JqnNeTX8ybPiQgvg1ymCoF8LXs5fzFaZvJPTA=="
+    },
+    "node_modules/to-regex-range": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "dependencies": {
+        "is-number": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=8.0"
+      }
+    },
+    "node_modules/tough-cookie": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-5.1.2.tgz",
+      "integrity": "sha512-FVDYdxtnj0G6Qm/DhNPSb8Ju59ULcup3tuJxkFb5K8Bv2pUXILbf0xZWU8PX8Ov19OXljbUyveOFwRMwkXzO+A==",
+      "dependencies": {
+        "tldts": "^6.1.32"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/ts-mixer": {
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/ts-mixer/-/ts-mixer-6.0.4.tgz",
+      "integrity": "sha512-ufKpbmrugz5Aou4wcr5Wc1UUFWOLhq+Fm6qa6P0w0K5Qw2yhaUoiWszhCVuNQyNwrlGiscHOmqYoAox1PtvgjA=="
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
+    },
+    "node_modules/tweetnacl": {
+      "version": "1.0.3",
+      "integrity": "sha512-6rt+RN7aOi1nGMyC4Xa5DdYiukl2UWCbcJft7YhxReBGQD7OAM8Pbxw6YMo4r2diNEA8FEmu32YOn9rhaiE5yw=="
+    },
+    "node_modules/typedarray": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+      "integrity": "sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA=="
+    },
+    "node_modules/undici": {
+      "version": "7.10.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.10.0.tgz",
+      "integrity": "sha512-u5otvFBOBZvmdjWLVW+5DAc9Nkq8f24g0O9oY7qw2JVIF1VocIFoyz9JFkuVOS2j41AufeO0xnlweJ2RLT8nGw==",
+      "engines": {
+        "node": ">=20.18.1"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
+    },
+    "node_modules/wrap-ansi": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.18.2",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.18.2.tgz",
+      "integrity": "sha512-DMricUmwGZUVr++AEAe2uiVM7UoO9MAVZMDu05UQOaUII0lp+zOzLLU4Xqh/JvTqklB1T4uELaaPBKyjE1r4fQ==",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/y18n": {
+      "version": "5.0.8",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
+      "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/yaml": {
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
+      "integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==",
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/yargs": {
+      "version": "16.2.0",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-16.2.0.tgz",
+      "integrity": "sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==",
+      "dependencies": {
+        "cliui": "^7.0.2",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.0",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^20.2.2"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/yargs-parser": {
+      "version": "20.2.9",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-20.2.9.tgz",
+      "integrity": "sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==",
+      "engines": {
+        "node": ">=10"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -10,12 +10,17 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "@discordjs/voice": "^0.17.0",
-    "@distube/ytdl-core": "^4.16.4",
-    "discord.js": "^14.15.3",
+    "@discordjs/voice": "^0.18.0",
+    "@distube/yt-dlp": "^2.0.1",
+    "@distube/ytdl-core": "^4.16.11",
+    "depcheck": "^1.4.7",
+    "discord.js": "^14.19.3",
+    "distube": "^5.0.7",
     "ffmpeg-static": "^5.2.0",
     "genius-lyrics": "^4.4.7",
+    "opusscript": "^0.0.8",
     "play-dl": "^1.9.7",
+    "prism-media": "^1.3.5",
     "tweetnacl": "^1.0.3"
   }
 }

--- a/replace.js
+++ b/replace.js
@@ -1,0 +1,24 @@
+const fs = require('fs');
+const path = require('path');
+
+function replaceInFile(filePath) {
+  let content = fs.readFileSync(filePath, 'utf8');
+  if (content.includes('flags: 64')) {
+    content = content.replace(/ephemeral: *true/g, 'flags: 64');
+    fs.writeFileSync(filePath, content, 'utf8');
+    console.log(`✔ Replaced in ${filePath}`);
+  }
+}
+
+function walk(dir) {
+  fs.readdirSync(dir).forEach(file => {
+    const fullPath = path.join(dir, file);
+    if (fs.lstatSync(fullPath).isDirectory()) {
+      walk(fullPath);
+    } else if (fullPath.endsWith('.js')) {
+      replaceInFile(fullPath);
+    }
+  });
+}
+
+walk('./'); // Start from the current directory


### PR DESCRIPTION
## 🎵 Features

- Added queue pagination (10 songs per page)
- Enabled song queue search and jump-to-page
- Introduced "Insert Play" function to add and play a song immediately
- Added "Back to Playlist" feature on the search result page
  > 🔧 Note: Global interaction registration for "Back to Playlist" is not yet complete — buttons will not work after timeout

## 🐞 Bug Fixes

- Fixed playback errors causing bot to crash or disconnect
- Resolved issues with YouTube links failing due to play-dl problems
- Fixed command triggers not responding under certain conditions

## 🧹 Refactor & Code Structure

- Refactored `play.js`, `queue.js`, and separated logic into `lib/` and `handlers/`
- Introduced `checkReply.js` to standardize `reply` and `editReply` handling
- Added `.gitignore` to ignore `node_modules/`, `config.json`, `.env`, and temp files

## 🔧 Other Notes

- Added `disable-ipv6.txt` to document a workaround for YouTube streaming issues on Ubuntu (ETIMEDOUT / ENETUNREACH errors)
- Reorganized command structure for maintainability

## ✅ Testing

All features tested locally in a private Discord server:
- Pagination and navigation
- Insert play behavior and skipping
- Search and playback from search
- Button interactions and fallback handling